### PR TITLE
Move queueserver annotation logic to its own file, and add it to the expanded plan stubs

### DIFF
--- a/src/sophys/common/plans/annotated_default_plans.py
+++ b/src/sophys/common/plans/annotated_default_plans.py
@@ -27,13 +27,13 @@ as the first row, but unlike the second row, it must have all elements be non-em
 ``typing.Any``.
 """
 
-import copy
 import functools
-import inspect
 import typing
 
 import cycler
 from bluesky import plans, plan_stubs, protocols, Msg
+
+from .queueserver_annotation import parameter_annotation_decorator, DEFAULT_ANNOTATION
 
 
 __all__ = [
@@ -98,18 +98,6 @@ PER_STEP_TYPE = typing.Callable[
 ]
 
 
-DEFAULT_ANNOTATION = {
-    "parameters": {
-        "detectors": {
-            "convert_device_names": True,
-        },
-        "md": {
-            "convert_device_names": False,
-        },
-    },
-}
-
-
 # https://docs.python.org/3/library/functools.html#functools.update_wrapper
 # This removes __annotations__, so our type hints get through.
 WRAPPER_ASSIGNMENTS = ["__module__", "__name__", "__qualname__", "__doc__"]
@@ -126,57 +114,6 @@ def wraps(wrapped_func):
         return wrapped
 
     return __wrapper__
-
-
-try:
-    from bluesky_queueserver.manager.annotation_decorator import (
-        parameter_annotation_decorator,
-    )
-except ImportError:
-
-    def parameter_annotation_decorator(annotation):
-        """
-        Copy of the official one, without validation.
-        See https://github.com/bluesky/bluesky-queueserver/blob/main/bluesky_queueserver/manager/annotation_decorator.py
-        """
-
-        def function_wrap(func):
-            if inspect.isgeneratorfunction(func):
-
-                @functools.wraps(func)
-                def wrapper(*args, **kwargs):
-                    return (yield from func(*args, **kwargs))
-
-            else:
-
-                @functools.wraps(func)
-                def wrapper(*args, **kwargs):
-                    return func(*args, **kwargs)
-
-            # Always create the copy (annotation dictionary may be reused)
-            nonlocal annotation
-            annotation = copy.deepcopy(annotation)
-
-            sig = inspect.signature(func)
-            parameters = sig.parameters
-
-            param_unknown = []
-            if "parameters" in annotation:
-                for p in annotation["parameters"]:
-                    if p not in parameters:
-                        param_unknown.append(p)
-            if param_unknown:
-                msg = (
-                    f"Custom annotation parameters {param_unknown} are not "
-                    f"in the signature of function '{func.__name__}'."
-                )
-                raise ValueError(msg)
-
-            setattr(wrapper, "_custom_parameter_annotation_", annotation)
-
-            return wrapper
-
-        return function_wrap
 
 
 @parameter_annotation_decorator(DEFAULT_ANNOTATION)

--- a/src/sophys/common/plans/expanded_plan_stubs.py
+++ b/src/sophys/common/plans/expanded_plan_stubs.py
@@ -1,6 +1,16 @@
 from bluesky import preprocessors as bpp, plan_stubs as bps
 
 from .annotated_default_plans import mv, mvr, read
+from .queueserver_annotation import parameter_annotation_decorator
+
+
+_ANNOTATION = {
+    "parameters": {
+        "md": {
+            "convert_device_names": False,
+        },
+    },
+}
 
 
 def _read_many(devices):
@@ -10,6 +20,7 @@ def _read_many(devices):
     yield from bps.save()
 
 
+@parameter_annotation_decorator(_ANNOTATION)
 def read_many(devices, md=None):
     """Take a reading of many devices, and bundle them into a single Bluesky document."""
 
@@ -20,6 +31,7 @@ def read_many(devices, md=None):
     return (yield from __inner())
 
 
+@parameter_annotation_decorator(_ANNOTATION)
 def mov(*args, md=None):
     """Move many devices, and bundle their start and end positions in Bluesky documents."""
 
@@ -34,6 +46,7 @@ def mov(*args, md=None):
     return (yield from __inner())
 
 
+@parameter_annotation_decorator(_ANNOTATION)
 def rmov(*args, md=None):
     """Move many devices, and bundle their start and end positions in Bluesky documents."""
 

--- a/src/sophys/common/plans/queueserver_annotation.py
+++ b/src/sophys/common/plans/queueserver_annotation.py
@@ -1,0 +1,65 @@
+try:
+    from bluesky_queueserver.manager.annotation_decorator import (
+        parameter_annotation_decorator,
+    )
+except ImportError:
+    import copy
+    import functools
+    import inspect
+
+    def parameter_annotation_decorator(annotation):
+        """
+        Copy of the official one, without validation.
+        See https://github.com/bluesky/bluesky-queueserver/blob/main/bluesky_queueserver/manager/annotation_decorator.py
+        """
+
+        def function_wrap(func):
+            if inspect.isgeneratorfunction(func):
+
+                @functools.wraps(func)
+                def wrapper(*args, **kwargs):
+                    return (yield from func(*args, **kwargs))
+
+            else:
+
+                @functools.wraps(func)
+                def wrapper(*args, **kwargs):
+                    return func(*args, **kwargs)
+
+            # Always create the copy (annotation dictionary may be reused)
+            nonlocal annotation
+            annotation = copy.deepcopy(annotation)
+
+            sig = inspect.signature(func)
+            parameters = sig.parameters
+
+            param_unknown = []
+            if "parameters" in annotation:
+                for p in annotation["parameters"]:
+                    if p not in parameters:
+                        param_unknown.append(p)
+            if param_unknown:
+                msg = (
+                    f"Custom annotation parameters {param_unknown} are not "
+                    f"in the signature of function '{func.__name__}'."
+                )
+                raise ValueError(msg)
+
+            setattr(wrapper, "_custom_parameter_annotation_", annotation)
+
+            return wrapper
+
+        return function_wrap
+
+
+DEFAULT_ANNOTATION = {
+    "parameters": {
+        "detectors": {
+            "convert_device_names": True,
+        },
+        "md": {
+            "convert_device_names": False,
+        },
+    },
+}
+"""A minimal queueserver annotation, removing device name conversion from 'md'."""


### PR DESCRIPTION
I need this to set 'convert_device_names' to False in those plans, otherwise it does some dumdum stuff