### PR TITLE
Allow Picolo and Pimega devices to be used from Bluesky rather than from Ophyd directly

### DIFF
--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -1,6 +1,13 @@
 from time import time
-from ophyd import Device, Component, FormattedComponent, EpicsSignal, \
-    EpicsSignalWithRBV, DynamicDeviceComponent, EpicsSignalRO
+from ophyd import (
+    Device,
+    Component,
+    FormattedComponent,
+    EpicsSignal,
+    EpicsSignalWithRBV,
+    DynamicDeviceComponent,
+    EpicsSignalRO,
+)
 from ophyd.flyers import FlyerInterface
 from ophyd.status import SubscriptionStatus, StatusBase, Status
 
@@ -21,14 +28,15 @@ class PicoloChannel(Device):
     saturated = Component(EpicsSignal, "Saturated", kind="config")
     range = Component(EpicsSignalWithRBV, "Range", string=True, kind="config")
     auto_range = Component(EpicsSignalWithRBV, "AutoRange", kind="omitted")
-    acquire_mode = Component(EpicsSignalWithRBV, "AcquireMode", string=True, kind="config")
+    acquire_mode = Component(
+        EpicsSignalWithRBV, "AcquireMode", string=True, kind="config"
+    )
     state = Component(EpicsSignalRO, "State", string=True, kind="config")
     analog_bw = Component(EpicsSignalRO, "AnalogBW_RBV", kind="omitted")
-    
+
     user_offset = Component(EpicsSignalWithRBV, "UserOffset", kind="config")
     exp_offset = Component(EpicsSignalWithRBV, "ExpOffset", kind="config")
     set_zero = Component(EpicsSignal, "SetZero", kind="omitted")
-
 
     def __init__(self, prefix, **kwargs):
         self.continuous_value = prefix[:-1]
@@ -48,7 +56,7 @@ class PicoloAcquisitionTime(EpicsSignalWithRBV):
             s.set_exception(Exception())
             return s
 
-        return super().set(f"{int(acquisiton_time*1000)} ms", **kwargs)
+        return super().set(f"{int(acquisiton_time * 1000)} ms", **kwargs)
 
 
 class Picolo(Device):
@@ -73,8 +81,12 @@ class Picolo(Device):
 
     range = Component(EpicsSignal, "Range", string=True, kind="config")
     auto_range = Component(EpicsSignal, "AutoRange", kind="omitted")
-    acquisition_time = Component(PicoloAcquisitionTime, "AcquisitionTime", string=True, kind="config")
-    sample_rate = Component(EpicsSignalWithRBV, "SampleRate", string=True, kind="config")
+    acquisition_time = Component(
+        PicoloAcquisitionTime, "AcquisitionTime", string=True, kind="config"
+    )
+    sample_rate = Component(
+        EpicsSignalWithRBV, "SampleRate", string=True, kind="config"
+    )
     acquire_mode = Component(EpicsSignal, "AcquireMode", string=True, kind="config")
     samples_per_trigger = Component(EpicsSignalWithRBV, "NumAcquire", kind="config")
     data_reset = Component(DataResetSignal, "DataReset", kind="omitted")
@@ -82,10 +94,9 @@ class Picolo(Device):
     triggering = Component(EpicsSignal, "Triggering", kind="omitted")
     enable = Component(EpicsSignal, "Enable", kind="omitted")
 
-    continuous_mode = DynamicDeviceComponent({
-        "start_acq": (EpicsSignal, "Start", {}),
-        "stop_acq": (EpicsSignal, "Stop", {})
-    })
+    continuous_mode = DynamicDeviceComponent(
+        {"start_acq": (EpicsSignal, "Start", {}), "stop_acq": (EpicsSignal, "Stop", {})}
+    )
 
     ch1 = Component(PicoloChannel, "Current1:")
     ch2 = Component(PicoloChannel, "Current2:")
@@ -107,9 +118,9 @@ class PicoloFlyScan(Picolo, FlyerInterface):
         """
         num_exposures = self.samples_per_trigger.get()
         data_acquired = self.data_acquired.get()
-        if (data_acquired != num_exposures):
+        if data_acquired != num_exposures:
             return False
-            
+
         for channel in [self.ch1, self.ch2, self.ch3, self.ch4]:
             num_points_saved = len(channel.data.get())
             if channel.enable.get() and num_exposures != num_points_saved:
@@ -118,7 +129,7 @@ class PicoloFlyScan(Picolo, FlyerInterface):
 
     def complete(self):
         return SubscriptionStatus(self, callback=self._fly_scan_complete)
-    
+
     def describe_collect(self):
         descriptor = {"picolo": {}}
         for channel in [self.ch1, self.ch2, self.ch3, self.ch4]:
@@ -137,10 +148,4 @@ class PicoloFlyScan(Picolo, FlyerInterface):
                 data.update({dev_name: dev_info["value"]})
                 timestamps.update({dev_name: dev_info["timestamp"]})
 
-        return [
-            {
-                "time": time(),
-                "data": data,
-                "timestamps": timestamps
-            }
-        ]
+        return [{"time": time(), "data": data, "timestamps": timestamps}]

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -48,18 +48,18 @@ class PicoloChannel(Device):
 class PicoloAcquisitionTime(EpicsSignalWithRBV):
     """Device that handles set enum acquisition time using a float value in ms."""
 
-    def set(self, acquisiton_time: float, **kwargs):
+    def set(self, acquisition_time: float, **kwargs):
         enums = self.metadata["enum_strs"]
         enums_float = [(float(item.replace(" ms", "")) / 1000) for item in enums]
-        if acquisiton_time not in enums_float:
+        if acquisition_time not in enums_float:
             return PremadeStatus(
                 False,
                 exception=ValueError(
-                    f"The acquisition time '{acquisiton_time}' is not a valid option."
+                    f"The acquisition time '{acquisition_time}' is not a valid option."
                 ),
             )
 
-        return super().set(f"{int(acquisiton_time * 1000)} ms", **kwargs)
+        return super().set(f"{int(acquisition_time * 1000)} ms", **kwargs)
 
 
 class Picolo(Device):

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -2,7 +2,7 @@ from time import time
 from ophyd import Device, Component, FormattedComponent, EpicsSignal, \
     EpicsSignalWithRBV, DynamicDeviceComponent, EpicsSignalRO
 from ophyd.flyers import FlyerInterface
-from ophyd.status import SubscriptionStatus, StatusBase
+from ophyd.status import SubscriptionStatus, StatusBase, Status
 
 
 class PicoloChannel(Device):
@@ -36,18 +36,19 @@ class PicoloChannel(Device):
 
 
 class PicoloAcquisitionTime(EpicsSignalWithRBV):
-    """
-        Device that handles set enum acquisition time using a float in milliseconds.
-    """
+    """Device that handles set enum acquisition time using a float value in ms."""
 
-    def set_value(self, acquisiton_time: float):
-        enums = self.metadata['enum_strs']
-        enums_float = [(float(item.replace(" ms", ""))/1000) for item in enums]
+    def set(self, acquisiton_time: float, **kwargs):
+        enums = self.metadata["enum_strs"]
+        enums_float = [(float(item.replace(" ms", "")) / 1000) for item in enums]
         if acquisiton_time not in enums_float:
             print("Acquisition time not found")
-            return
 
-        super().set(f"{int(acquisiton_time*1000)} ms").wait()
+            s = Status()
+            s.set_exception(Exception())
+            return s
+
+        return super().set(f"{int(acquisiton_time*1000)} ms", **kwargs)
 
 
 class Picolo(Device):

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -9,6 +9,7 @@ from ophyd import (
     EpicsSignalRO,
 )
 from ophyd.flyers import FlyerInterface
+from ophyd.signal import DEFAULT_WRITE_TIMEOUT
 from ophyd.status import SubscriptionStatus, StatusBase, Status
 
 from ..utils.status import PremadeStatus
@@ -66,7 +67,7 @@ class Picolo(Device):
     """Device for the 4 channel Picolo picoammeter."""
 
     class DataResetSignal(EpicsSignal):
-        def set(self, value, **kwargs):
+        def set(self, value, *, timeout=DEFAULT_WRITE_TIMEOUT, settle_time=None):
             _s = Status()
             _s.set_finished()
             if value == 0:
@@ -76,9 +77,9 @@ class Picolo(Device):
 
             past_acquire_mode = parent.acquire_mode.get()
 
-            parent.acquire_mode.set(0).wait()  # Set continuous mode
-            super().set(value, **kwargs).wait()
-            parent.acquire_mode.set(past_acquire_mode).wait()
+            parent.acquire_mode.set(0, timeout=timeout).wait()  # Set continuous mode
+            super().set(value, timeout=timeout, settle_time=settle_time).wait()
+            parent.acquire_mode.set(past_acquire_mode, timeout=timeout).wait()
 
             return _s
 

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -11,6 +11,8 @@ from ophyd import (
 from ophyd.flyers import FlyerInterface
 from ophyd.status import SubscriptionStatus, StatusBase, Status
 
+from ..utils.status import PremadeStatus
+
 
 class PicoloChannel(Device):
     """
@@ -50,11 +52,12 @@ class PicoloAcquisitionTime(EpicsSignalWithRBV):
         enums = self.metadata["enum_strs"]
         enums_float = [(float(item.replace(" ms", "")) / 1000) for item in enums]
         if acquisiton_time not in enums_float:
-            print("Acquisition time not found")
-
-            s = Status()
-            s.set_exception(Exception())
-            return s
+            return PremadeStatus(
+                False,
+                exception=ValueError(
+                    f"The acquisition time '{acquisiton_time}' is not a valid option."
+                ),
+            )
 
         return super().set(f"{int(acquisiton_time * 1000)} ms", **kwargs)
 

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -6,7 +6,7 @@ from ophyd import (
     EpicsSignalRO,
     EpicsSignalWithRBV,
     SingleTrigger,
-    Device
+    Device,
 )
 from ophyd.status import SubscriptionStatus
 from ophyd.flyers import FlyerInterface
@@ -72,20 +72,24 @@ class PimegaCam(CamBase_V33):
     acquire = ADComponent(PimegaAcquire, "")
     num_capture = ADComponent(EpicsSignalWithRBV, "NumCapture")
     num_exposures = ADComponent(EpicsSignalWithRBV, "NumExposures")
-    
+
     acquire_time = ADComponent(EpicsSignalWithRBV, "AcquireTime")
     acquire_period = ADComponent(EpicsSignalWithRBV, "AcquirePeriod")
 
     medipix_mode = ADComponent(EpicsSignalWithRBV, "MedipixMode")
 
     detector_state = ADComponent(EpicsSignalRO, "DetectorState_RBV")
-    processed_acquisition_counter = ADComponent(EpicsSignalRO, "ProcessedAcquisitionCounter_RBV")
+    processed_acquisition_counter = ADComponent(
+        EpicsSignalRO, "ProcessedAcquisitionCounter_RBV"
+    )
     num_captured = ADComponent(EpicsSignalRO, "NumCaptured_RBV")
-    
+
     dac = ADComponent(Digital2AnalogConverter, "DAC_")
 
     file_name = ADComponent(EpicsSignalWithRBV, "FileName", string=True)
-    file_path = ADComponent(EpicsPathSignal, "FilePath", read_pv="FilePath_RBV", string=True)
+    file_path = ADComponent(
+        EpicsPathSignal, "FilePath", read_pv="FilePath_RBV", string=True
+    )
     file_path_exists = ADComponent(EpicsSignalRO, "FilePathExists_RBV", string=True)
     file_number = ADComponent(EpicsSignalWithRBV, "FileNumber")
     file_template = ADComponent(EpicsSignalWithRBV, "FileTemplate", string=True)
@@ -122,7 +126,7 @@ class PimegaFlyScan(Pimega, FlyerInterface):
 
     def complete(self):
         return SubscriptionStatus(self.cam, callback=self._fly_scan_complete)
-    
+
     def describe_collect(self):
         descriptor = {"pimega": {}}
         descriptor["pimega"].update(self.cam.file_name.describe())
@@ -138,10 +142,4 @@ class PimegaFlyScan(Pimega, FlyerInterface):
             data.update({dev_name: dev_info["value"]})
             timestamps.update({dev_name: dev_info["timestamp"]})
 
-        return [
-            {
-                "time": time(),
-                "data": data,
-                "timestamps": timestamps
-            }
-        ]
+        return [{"time": time(), "data": data, "timestamps": timestamps}]

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -11,6 +11,7 @@ from ophyd import (
 from ophyd.status import SubscriptionStatus
 from ophyd.flyers import FlyerInterface
 from ophyd.areadetector.detectors import DetectorBase
+from ophyd.areadetector.paths import EpicsPathSignal
 from .cam import CamBase_V33
 
 from ..utils.status import PremadeStatus
@@ -64,18 +65,6 @@ class PimegaAcquire(Device):
         return self.capture.set(0)
 
 
-class PimegaFilePath(EpicsSignalWithRBV):
-    """
-        Add '/' at the end of the file path if it isn't already specified.
-    """
-
-    def set(self, value: str, **kwargs):
-        if len(value) > 0:
-            if value[-1] != '/':
-                value += '/'
-        return super().set(value, **kwargs)
-
-
 class PimegaCam(CamBase_V33):
 
     magic_start = ADComponent(EpicsSignal, "MagicStart")
@@ -96,7 +85,7 @@ class PimegaCam(CamBase_V33):
     dac = ADComponent(Digital2AnalogConverter, "DAC_")
 
     file_name = ADComponent(EpicsSignalWithRBV, "FileName", string=True)
-    file_path = ADComponent(PimegaFilePath, "FilePath", string=True)
+    file_path = ADComponent(EpicsPathSignal, "FilePath", read_pv="FilePath_RBV", string=True)
     file_path_exists = ADComponent(EpicsSignalRO, "FilePathExists_RBV", string=True)
     file_number = ADComponent(EpicsSignalWithRBV, "FileNumber")
     file_template = ADComponent(EpicsSignalWithRBV, "FileTemplate", string=True)

--- a/src/sophys/common/utils/status.py
+++ b/src/sophys/common/utils/status.py
@@ -1,3 +1,5 @@
+import typing
+
 from ophyd.status import StatusBase
 
 
@@ -9,12 +11,22 @@ class PremadeStatus(StatusBase):
     ----------
     success : bool
         Whether this Status object should be configured as having failed (False) or succeeded (True).
+    exception : Exception, optional
+        The exception to set on the Status object when failed. Defaults to an empty Exception object.
+        NOTE: An exception cannot be set when the Status is successful.
     """
 
-    def __init__(self, success: bool):
+    def __init__(self, success: bool, *, exception: typing.Optional[Exception] = None):
         super().__init__()
 
         if success:
+            assert (
+                exception is None
+            ), "Cannot pass an exception when creating a successful Status object."
             self.set_finished()
         else:
-            self.set_exception(Exception())
+            _exc = exception
+            if exception is None:
+                _exc = Exception()
+
+            self.set_exception(_exc)

--- a/src/sophys/common/utils/status.py
+++ b/src/sophys/common/utils/status.py
@@ -1,0 +1,20 @@
+from ophyd.status import StatusBase
+
+
+class PremadeStatus(StatusBase):
+    """
+    A dummy Status object useful for simple Ophyd <-> Bluesky compatibility methods.
+
+    Parameters
+    ----------
+    success : bool
+        Whether this Status object should be configured as having failed (False) or succeeded (True).
+    """
+
+    def __init__(self, success: bool):
+        super().__init__()
+
+        if success:
+            self.set_finished()
+        else:
+            self.set_exception(Exception())

--- a/tests/utils/test_status.py
+++ b/tests/utils/test_status.py
@@ -1,0 +1,13 @@
+from sophys.common.utils.status import PremadeStatus
+
+
+def test_premade_status_success():
+    sts = PremadeStatus(True)
+    assert sts.done
+    assert sts.success
+
+
+def test_premade_status_fail():
+    sts = PremadeStatus(False)
+    assert sts.done
+    assert not sts.success

--- a/tests/utils/test_status.py
+++ b/tests/utils/test_status.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sophys.common.utils.status import PremadeStatus
 
 
@@ -11,3 +13,18 @@ def test_premade_status_fail():
     sts = PremadeStatus(False)
     assert sts.done
     assert not sts.success
+
+
+def test_premade_status_fail_custom_exception():
+    custom_exception = ValueError("something something")
+    sts = PremadeStatus(False, exception=custom_exception)
+    assert sts.done
+    assert not sts.success
+    assert sts.exception() == custom_exception
+
+
+def test_premade_status_success_with_exception():
+    custom_exception = ValueError("something something")
+
+    with pytest.raises(AssertionError):
+        PremadeStatus(True, exception=custom_exception)


### PR DESCRIPTION
This intends to give us a better framework to modify the RunEngine in a testing environment, ensuring no plans actually set values to the EPICS layer.

Fixes #7