### PR TITLE
Improve sorting of components with numerals in attribute lists on the documentation

### DIFF
--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -3,3 +3,4 @@ sphinx-design==0.5.0
 sphinx_rtd_theme==2.0.0
 sphinx-remove-toctrees==0.0.3
 sphinx-tags==0.3.1
+natsort==8.4.0

--- a/docs/source/_templates/device_attr_list.rst
+++ b/docs/source/_templates/device_attr_list.rst
@@ -10,7 +10,7 @@
    .. rubric:: {{ _('Attributes') }}
 
    .. autosummary::
-   {% for item in attributes %}
+   {% for item in (attributes | natural_sort) %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
    {% endif %}

--- a/docs/source/_templates/device_attr_list_embed.rst
+++ b/docs/source/_templates/device_attr_list_embed.rst
@@ -8,7 +8,7 @@
    .. rubric:: {{ _('Attributes') }}
 
    .. autosummary::
-   {% for item in attributes %}
+   {% for item in (attributes | natural_sort) %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
    {% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,3 +108,25 @@ def setup(app):
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 html_css_files = ["css/custom_theming.css"]
+
+
+# Jinja custom filters
+
+from jinja2.filters import FILTERS
+
+
+def natural_sort(input, key=None, reverse=False, ignore_case=True):
+    """
+    Sort a list naturally, e.g. [A1, B1, A2, A10] will sort into [A1, A2, A10, B1].
+    Ref.: https://gist.github.com/dylanjnz/bfc16c02972521f5c8fea58d3b303071
+    """
+    from natsort import natsorted, ns
+
+    alg = ns.IGNORECASE
+    if not ignore_case:
+        alg = ns.LOWERCASEFIRST
+
+    return natsorted(input, key=key, reverse=reverse, alg=alg)
+
+
+FILTERS["natural_sort"] = natural_sort


### PR DESCRIPTION
This ensures signals such as `aiX` follow their natural ordering, instead of direct sorting. An example is the following:

Before:
![wrong ordering of signals: ai0, ai1, ai10, ai11, ai12, ai13](https://github.com/user-attachments/assets/845f783c-4983-4592-9a77-7e268f60329b)

After:
![correct ordering of signals: ai0, ai1, ai2, ai3, ai4, ai5](https://github.com/user-attachments/assets/d6b07666-1a5c-4b49-9e67-d56b03a4b747)