### PR TITLE
Avoid running the testing CI workflow when no code has been changed

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,22 @@
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  linting:
+    name: Run pre-commit
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.12
+      - uses: actions/checkout@v4
+      - name: Acquire changed files
+        id: changed_files
+        uses: tj-actions/changed-files@v45.0.5
+      - name: Run pre-commit on the changed files
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --files ${{ steps.changed_files.outputs.all_changed_files}}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+      - "!docs/**"
 
 jobs:
   test:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,20 +22,3 @@ jobs:
           kafka-topics: "test_bluesky_raw_docs,1"
       - name: Run pytest
         run: pytest -vvv
-
-  linting:
-    name: Run pre-commit
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v5.3.0
-        with:
-          python-version: 3.12
-      - uses: actions/checkout@v4
-      - name: Acquire changed files
-        id: changed_files
-        uses: tj-actions/changed-files@v45.0.5
-      - name: Run pre-commit on the changed files
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --files ${{ steps.changed_files.outputs.all_changed_files}}


### PR DESCRIPTION
This is to avoid unnecessarily running jobs when e.g. changing only the project documentation.