### PR TITLE
Fix ophyd version in main branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = [
   "bluesky",
-  "ophyd",
+  "ophyd<=1.10",
   "numpy==1.26.4"
 ]
 


### PR DESCRIPTION
This ensures the 4.x releases do not suffer from an issue in newer Ophyd versions, which will be fixed in sophys-common's 5.0.0 release.

The issue in question is addressed in #16.