### PR TITLE
Fix documentation autogeneration for Tatu and Xspress devices

### DIFF
--- a/docs/source/devices_controllers.rst
+++ b/docs/source/devices_controllers.rst
@@ -141,7 +141,7 @@ Each input and output are themselves Ophyd devices with some specific signals:
     .. include:: _generated/sophys.common.devices.tatu.TatuInput.rst
 
     .. include:: _generated/sophys.common.devices.tatu.TatuOutput.rst
-            .
+
     .. include:: _generated/sophys.common.devices.tatu.TatuOutputV2.rst
 
     Each output condition, in turn, has its own signals:

--- a/docs/source/devices_detectors.rst
+++ b/docs/source/devices_detectors.rst
@@ -101,11 +101,11 @@ Pimega
 
 ----
 
-Vortex
-------
+Vortex / Xspress
+----------------
 
 .. tags:: AreaDetector
 
-.. automodule:: sophys.common.devices.vortex
+.. automodule:: sophys.common.devices.xspress
     :members:
     :show-inheritance:


### PR DESCRIPTION
We didn't catch those in review... Maybe it would be a good idea to test documentation builds regularly too.