### PR TITLE
Directly include kafka callback in the documentation's utils callbacks section

### DIFF
--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -4,7 +4,7 @@ Utility
 Callbacks
 ---------
 
-.. automodule:: sophys.common.utils.callbacks
+.. automodule:: sophys.common.utils.kafka.callback
     :members:
     :show-inheritance:
 


### PR DESCRIPTION
Since we moved it, the documentation section got empty