### PR TITLE
Fix Picolo device to match IOC implementation

### DIFF
--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -42,7 +42,7 @@ class EnumAcquisitionTimeValidator(IEnumValidator):
         return enum_value in self._enums
 
 
-class PicoloAcquisitionTimeBaseMixin:
+class PicoloAcquisitionTimeMixin:
     """A base mix-in class for picolo AcquisitionTime."""
 
     def __init__(self, *args, **kwargs):
@@ -63,13 +63,13 @@ class PicoloAcquisitionTimeBaseMixin:
         return super().set(formatted_time, *args, **kwargs)
 
 
-class PicoloAcquisitionTime(PicoloAcquisitionTimeBaseMixin, EpicsSignal):
+class PicoloAcquisitionTime(PicoloAcquisitionTimeMixin, EpicsSignal):
     """PicoloAcquisitionTime using EpicsSignal."""
 
     pass
 
 
-class PicoloAcquisitionTimeWithRBV(PicoloAcquisitionTimeBaseMixin, EpicsSignalWithRBV):
+class PicoloAcquisitionTimeWithRBV(PicoloAcquisitionTimeMixin, EpicsSignalWithRBV):
     """PicoloAcquisitionTime using EpicsSignalWithRBV."""
 
     pass

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -35,7 +35,7 @@ class PicoloChannel(Device):
         EpicsSignalWithRBV, "AcquireMode", string=True, kind="config"
     )
     state = Component(EpicsSignalRO, "State", string=True, kind="config")
-    analog_bw = Component(EpicsSignalRO, "AnalogBW_RBV", kind="omitted")
+    analog_bw = Component(EpicsSignalRO, "BW_RBV", kind="omitted")
 
     user_offset = Component(EpicsSignalWithRBV, "UserOffset", kind="config")
     exp_offset = Component(EpicsSignalWithRBV, "ExpOffset", kind="config")

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -96,6 +96,9 @@ class Picolo(Device):
     data_acquired = Component(EpicsSignal, "DataAcquired", kind="config")
     triggering = Component(EpicsSignal, "Triggering", kind="omitted")
     enable = Component(EpicsSignal, "Enable", kind="omitted")
+    common_sample_rate = Component(
+        EpicsSignal, "SampleRate", string=True, kind="omitted"
+    )
 
     continuous_mode = DynamicDeviceComponent(
         {"start_acq": (EpicsSignal, "Start", {}), "stop_acq": (EpicsSignal, "Stop", {})}

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -22,19 +22,8 @@ class EnumAcquisitionTimeValidator(IEnumValidator):
     def __init__(self, enum_string):
         self._enums = [float(item.replace(" ms", "")) / 1000 for item in enum_string]
 
-    def is_valid(self, enum_value: float) -> bool:
-        return enum_value in self._enums
-
-
-class PicoloAcquisitionTimeBase:
-    """Base class for handling acquisition time."""
-
-    def __init__(self, validator: IEnumValidator):
-        self.validator = validator
-
-    def format_acquisition_time(self, acquisition_time: float) -> str:
-        """Convert float acquisition time to formatted string."""
-        ms_value = acquisition_time * 1000  # Convert seconds to milliseconds
+    def format_to_enum(self, value):
+        ms_value = value * 1000  # Convert seconds to milliseconds
 
         if ms_value == int(ms_value):
             return f"{int(ms_value)} ms"
@@ -43,11 +32,14 @@ class PicoloAcquisitionTimeBase:
 
     def validate_and_format(self, acquisition_time: float):
         """Validate and format acquisition time."""
-        if not self.validator.is_valid(acquisition_time):
+        if not self.is_valid(acquisition_time):
             raise ValueError(
                 f"The acquisition time '{acquisition_time}' ms is not a valid option."
             )
-        return self.format_acquisition_time(acquisition_time)
+        return self.format_to_enum(acquisition_time)
+
+    def is_valid(self, enum_value: float) -> bool:
+        return enum_value in self._enums
 
 
 class PicoloAcquisitionTimeBaseMixin:
@@ -56,9 +48,7 @@ class PicoloAcquisitionTimeBaseMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.wait_for_connection(DEFAULT_CONNECTION_TIMEOUT)
-        self._time_base_validator = PicoloAcquisitionTimeBase(
-            EnumAcquisitionTimeValidator(self.enum_strs)
-        )
+        self._time_base_validator = EnumAcquisitionTimeValidator(self.enum_strs)
 
     def set(self, acquisition_time: float, *args, **kwargs):
         try:

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -43,7 +43,14 @@ class EnumAcquisitionTimeValidator(IEnumValidator):
 
 
 class PicoloAcquisitionTimeMixin:
-    """A base mix-in class for picolo AcquisitionTime."""
+    """A mix-in class for handling acquisition time configuration.
+
+    This mix-in assumes the presence of a base interface that provides
+    the methods `wait_for_connection` and `set`, which are expected to be
+    inherited from another class. Upon initialization, it ensures a connection
+    is established and validates acquisition time values using an
+    enumeration-based validator before passing them to the base `set` method.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -56,6 +56,9 @@ class PicoloChannel(Device):
     acquisition_time = Component(
         PicoloAcquisitionTime, "AcquisitionTime", string=True, kind="config"
     )
+    sample_rate = Component(
+        EpicsSignalWithRBV, "SampleRate", string=True, kind="config"
+    )
     user_offset = Component(EpicsSignalWithRBV, "UserOffset", kind="config")
     exp_offset = Component(EpicsSignalWithRBV, "ExpOffset", kind="config")
     set_zero = Component(EpicsSignal, "SetZero", kind="omitted")
@@ -87,9 +90,6 @@ class Picolo(Device):
 
     range = Component(EpicsSignal, "Range", string=True, kind="config")
     auto_range = Component(EpicsSignal, "AutoRange", kind="omitted")
-    sample_rate = Component(
-        EpicsSignalWithRBV, "SampleRate", string=True, kind="config"
-    )
     acquire_mode = Component(EpicsSignal, "AcquireMode", string=True, kind="config")
     samples_per_trigger = Component(EpicsSignalWithRBV, "NumAcquire", kind="config")
     data_reset = Component(DataResetSignal, "DataReset", kind="omitted")

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -51,7 +51,7 @@ class PicoloAcquisitionTimeBase:
 
 
 class PicoloAcquisitionTimeBaseMixin:
-    """Simple variant of PicoloAcquisitionTime using EpicsSignal."""
+    """A base mix-in class for picolo AcquisitionTime."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/sophys/common/utils/__init__.py
+++ b/src/sophys/common/utils/__init__.py
@@ -11,6 +11,7 @@ from ophyd.areadetector.filestore_mixins import FileStoreHDF5IterativeWrite
 from .callbacks import *  # noqa: F403
 from .registry import *  # noqa: F403
 from .signals import *  # noqa: F403
+from .interfaces import *  # noqa: F403
 
 
 class HDF5PluginWithFileStore(HDF5Plugin, FileStoreHDF5IterativeWrite):
@@ -144,10 +145,12 @@ class HDF5PluginWithFileStore(HDF5Plugin, FileStoreHDF5IterativeWrite):
             self.file_name.set(file_name).wait()
             self.file_number.set(file_number + (1 if auto_increment else 0)).wait()
 
+
 class HDF5PluginWithFileStoreV34(HDF5PluginWithFileStore):
     file_number_sync = None
     file_number_write = None
     pool_max_buffers = None
+
 
 @dataclass
 class DebugOptions:

--- a/src/sophys/common/utils/interfaces.py
+++ b/src/sophys/common/utils/interfaces.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+
+class IEnumValidator(ABC):
+    """Abstract base class for enum validation."""
+
+    @abstractmethod
+    def is_valid(self, enum_value) -> bool:
+        """Check if acquisition time is valid."""
+        pass

--- a/src/sophys/common/utils/interfaces.py
+++ b/src/sophys/common/utils/interfaces.py
@@ -8,3 +8,13 @@ class IEnumValidator(ABC):
     def is_valid(self, enum_value) -> bool:
         """Check if acquisition time is valid."""
         pass
+
+    @abstractmethod
+    def format_to_enum(self, value) -> str:
+        """Format an input value to its enum correspondent"""
+        pass
+
+    @abstractmethod
+    def validate_and_format(self, value: float) -> bool:
+        """Validate and format acquisition time."""
+        pass

--- a/src/sophys/common/utils/interfaces.py
+++ b/src/sophys/common/utils/interfaces.py
@@ -13,8 +13,3 @@ class IEnumValidator(ABC):
     def format_to_enum(self, value) -> str:
         """Format an input value to its enum correspondent"""
         pass
-
-    @abstractmethod
-    def validate_and_format(self, value: float) -> bool:
-        """Validate and format acquisition time."""
-        pass

--- a/tests/test_picolo.py
+++ b/tests/test_picolo.py
@@ -1,0 +1,72 @@
+import pytest
+from sophys.common.devices.picolo import (
+    EnumAcquisitionTimeValidator,
+    PicoloAcquisitionTimeBase,
+    PicoloAcquisitionTimeBaseMixin,
+)
+
+
+@pytest.fixture
+def enum_validator():
+    """Fixture for EnumAcquisitionTimeValidator."""
+    return EnumAcquisitionTimeValidator(
+        (
+            "200 ms",
+            "100 ms",
+            "6.25 ms",
+            "25 ms",
+            "12.5 ms",
+            "50 ms",
+            "3.125 ms",
+            "1.5625 ms",
+            "1 ms",
+            "0.5 ms",
+        )
+    )
+
+
+@pytest.fixture
+def picolo_base(enum_validator):
+    """Fixture for PicoloAcquisitionTimeBase."""
+    return PicoloAcquisitionTimeBase(enum_validator)
+
+
+def test_enum_acquisition_time_validator_valid_value(enum_validator):
+    """Test if valid acquisition time is correctly validated."""
+    assert enum_validator.is_valid(0.2)
+    assert enum_validator.is_valid(0.1)
+    assert enum_validator.is_valid(0.0005)
+
+
+def test_enum_acquisition_time_validator_invalid_value(enum_validator):
+    """Test if invalid acquisition time is correctly rejected."""
+    assert not enum_validator.is_valid(30.0)  # Invalid value
+
+
+def test_format_acquisition_time_with_whole_number(picolo_base):
+    """Test if the time is formatted correctly for whole numbers."""
+    assert picolo_base.format_acquisition_time(0.01) == "10 ms"  # 10ms (0.01 seconds)
+
+
+def test_format_acquisition_time_with_decimal(picolo_base):
+    """Test if the time is formatted correctly for decimal values."""
+    assert picolo_base.format_acquisition_time(0.015) == "15 ms"  # 15ms (0.015 seconds)
+
+
+def test_format_acquisition_time_with_integer_seconds(picolo_base):
+    """Test if an integer seconds value gets formatted without decimal."""
+    assert picolo_base.format_acquisition_time(1) == "1000 ms"  # 1 second = 1000ms
+
+
+def test_validate_and_format_valid_time(picolo_base):
+    """Test if valid acquisition time is validated and formatted correctly."""
+    valid_time = 0.1  # 100 ms
+    formatted_time = picolo_base.validate_and_format(valid_time)
+    assert formatted_time == "100 ms"
+
+
+def test_validate_and_format_invalid_time(picolo_base):
+    """Test if invalid acquisition time raises an error."""
+    invalid_time = 0.03  # Not in enum values
+    with pytest.raises(ValueError):
+        picolo_base.validate_and_format(invalid_time)

--- a/tests/test_picolo.py
+++ b/tests/test_picolo.py
@@ -1,7 +1,6 @@
 import pytest
 from sophys.common.devices.picolo import (
     EnumAcquisitionTimeValidator,
-    PicoloAcquisitionTimeBase,
     PicoloAcquisitionTimeBaseMixin,
 )
 
@@ -25,12 +24,6 @@ def enum_validator():
     )
 
 
-@pytest.fixture
-def picolo_base(enum_validator):
-    """Fixture for PicoloAcquisitionTimeBase."""
-    return PicoloAcquisitionTimeBase(enum_validator)
-
-
 def test_enum_acquisition_time_validator_valid_value(enum_validator):
     """Test if valid acquisition time is correctly validated."""
     assert enum_validator.is_valid(0.2)
@@ -43,30 +36,30 @@ def test_enum_acquisition_time_validator_invalid_value(enum_validator):
     assert not enum_validator.is_valid(30.0)  # Invalid value
 
 
-def test_format_acquisition_time_with_whole_number(picolo_base):
+def test_format_to_enum_with_whole_number(enum_validator):
     """Test if the time is formatted correctly for whole numbers."""
-    assert picolo_base.format_acquisition_time(0.01) == "10 ms"  # 10ms (0.01 seconds)
+    assert enum_validator.format_to_enum(0.01) == "10 ms"  # 10ms (0.01 seconds)
 
 
-def test_format_acquisition_time_with_decimal(picolo_base):
+def test_format_to_enum_with_decimal(enum_validator):
     """Test if the time is formatted correctly for decimal values."""
-    assert picolo_base.format_acquisition_time(0.015) == "15 ms"  # 15ms (0.015 seconds)
+    assert enum_validator.format_to_enum(0.015) == "15 ms"  # 15ms (0.015 seconds)
 
 
-def test_format_acquisition_time_with_integer_seconds(picolo_base):
+def test_format_to_enum_with_integer_seconds(enum_validator):
     """Test if an integer seconds value gets formatted without decimal."""
-    assert picolo_base.format_acquisition_time(1) == "1000 ms"  # 1 second = 1000ms
+    assert enum_validator.format_to_enum(1) == "1000 ms"  # 1 second = 1000ms
 
 
-def test_validate_and_format_valid_time(picolo_base):
+def test_validate_and_format_valid_time(enum_validator):
     """Test if valid acquisition time is validated and formatted correctly."""
     valid_time = 0.1  # 100 ms
-    formatted_time = picolo_base.validate_and_format(valid_time)
+    formatted_time = enum_validator.validate_and_format(valid_time)
     assert formatted_time == "100 ms"
 
 
-def test_validate_and_format_invalid_time(picolo_base):
+def test_validate_and_format_invalid_time(enum_validator):
     """Test if invalid acquisition time raises an error."""
     invalid_time = 0.03  # Not in enum values
     with pytest.raises(ValueError):
-        picolo_base.validate_and_format(invalid_time)
+        enum_validator.validate_and_format(invalid_time)

--- a/tests/test_picolo.py
+++ b/tests/test_picolo.py
@@ -1,7 +1,7 @@
 import pytest
 from sophys.common.devices.picolo import (
     EnumAcquisitionTimeValidator,
-    PicoloAcquisitionTimeBaseMixin,
+    PicoloAcquisitionTimeMixin,
 )
 
 


### PR DESCRIPTION
As described in #30. Picolo IOC V2 will be deployed very soon, this deploy will make every Picolo device incompatible with the IOC, since multiple PV names and suffixes have changed. 

Main changes:

- [AnalogBW_RBV PV became BW_RBV](https://github.com/cnpem/sophys-common/commit/429381b3e4e7ff08109336a4b9acd131128ea974)
- [Acquisition Time PV is configurable per channel](https://github.com/cnpem/sophys-common/commit/3bbea0ed930011ad1fa1af5a1e2a57a8303a7a78)
- [Sample rate is configurable per channel](https://github.com/cnpem/sophys-common/commit/851ee0a51b78f3ac9604120c2a594be9081ba176)
- [Refactor AcquitisionTime](https://github.com/cnpem/sophys-common/pull/36/commits/bb65a85acb92589e7d69bfe5aaca43991882588b)
- [Add tests to AcquisitionTime Enum](https://github.com/cnpem/sophys-common/pull/36/commits/5aa6d3a933f44763a16693a94c7b1df12dce36d2)

This closes #30.