### PR TITLE
Add helper function to install packages via pip

### DIFF
--- a/src/sophys/common/utils/pip.py
+++ b/src/sophys/common/utils/pip.py
@@ -1,0 +1,52 @@
+import typing
+
+
+def install_package(
+    package_name: str,
+    version: typing.Optional[str] = None,
+    extra_index_url: typing.Optional[list[str]] = None,
+    force_reinstall: bool = False,
+    disable_cache: bool = False,
+):
+    """
+    Installs a package via pip.
+
+    Parameters
+    ----------
+    package_name : str
+        Name of the package, as is found on the package registry. Also
+        accepts Git URLs (i.e. git+https://...).
+    version : str, optional
+        Version of the package. Specified with the limiter.
+        e.g.: '==1.6.4', '>= 0.7.0', '~=1.10.0'
+    extra_index_url : list of str, optional
+        Extra package registry index locations to search the package in.
+    force_reinstall : bool, optional
+        Force reinstallation of the package in case it's already installed.
+    disable_cache : bool, optional
+        Disable caching of package wheels and HTTP responses by pip.
+    """
+
+    import subprocess
+    from sys import executable as _python_exec
+
+    command = [_python_exec, "-m", "pip", "install"]
+    if extra_index_url is not None:
+        for url in extra_index_url:
+            command.extend(["--extra-index-url", url])
+    if force_reinstall:
+        command.append("--force-reinstall")
+    if disable_cache:
+        command.append("--no-cache-dir")
+    command.append("{}{}".format(package_name, version or ""))
+
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(str(e))
+        print("  Standard output:")
+        print(e.stdout)
+        print("  Standard error:")
+        print(e.stderr)
+
+        raise RuntimeError(f"Package installation failed: {package_name}") from e

--- a/tests/utils/test_pip.py
+++ b/tests/utils/test_pip.py
@@ -1,0 +1,52 @@
+import pytest
+
+import sys
+
+from unittest.mock import patch
+
+from sophys.common.utils.pip import install_package
+
+
+@pytest.fixture
+def mocked_subprocess():
+    with patch("subprocess.run") as mock:
+        yield mock
+
+
+@pytest.mark.parametrize(
+    ("in_kwargs", "out_args"),
+    (
+        ({}, []),
+        ({"version": "==1.2.3"}, []),
+        ({"version": "~=1.2.3"}, []),
+        ({"extra_index_url": ["www.com"]}, ["--extra-index-url", "www.com"]),
+        (
+            {"extra_index_url": ["www.com", "www.org"]},
+            ["--extra-index-url", "www.com", "--extra-index-url", "www.org"],
+        ),
+        ({"force_reinstall": True}, ["--force-reinstall"]),
+        ({"disable_cache": True}, ["--no-cache-dir"]),
+        (
+            {"version": "==1.2.3", "force_reinstall": True, "disable_cache": True},
+            ["--force-reinstall", "--no-cache-dir"],
+        ),
+    ),
+)
+def test_simple_installation(mocked_subprocess, in_kwargs, out_args):
+    target = "sophys-common"
+
+    install_package(target, **in_kwargs)
+
+    target_with_ver = target + in_kwargs.get("version", "")
+    expected_command = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        *out_args,
+        target_with_ver,
+    ]
+
+    mocked_subprocess.assert_called_once_with(
+        expected_command, check=True, capture_output=True, text=True
+    )


### PR DESCRIPTION
We previously had this function created locally in each `sophys-server` repository, each doing its own thing. For maintenance, it seemed better to have it here, and have the base `queueserver` image come with this package installed with this function available already.

Furthermore, compared with that version, this one allows us to disable the pip cache, which is responsible for some unwanted disk usage on our container images.