### PR TITLE
Add factory function for simulated Ophyd devices

### DIFF
--- a/docs/source/devices_misc.rst
+++ b/docs/source/devices_misc.rst
@@ -116,3 +116,26 @@ High Voltage Power Supply (HVPS)
         sophys.common.devices.hvps.HVPS
 
 .. include:: _generated/sophys.common.devices.hvps.HVPS.rst
+
+
+Simulated devices
+-----------------
+
+We have also implemented a factory function to create some simulated devices, mainly for testing and development usage. It is the :py:func:`instantiate_sim_devices` function, importable from :py:mod:`sophys.common.devices`.
+
+It is inspired by the :py:mod:`ophyd.sim` module, but with some trimming down and fixes for our specific requirements.
+
+Example usage:
+
+
+.. code-block:: python
+
+    from sophys.common.devices import instantiate_sim_devices
+
+    hw = instantiate_sim_devices()
+
+    from bluesky import RunEngine
+    from bluesky.plans import scan
+
+    RE = RunEngine()
+    RE(scan([hw.det, hw.rand], hw.motor, -2, 2, 25))

--- a/src/sophys/common/devices/__init__.py
+++ b/src/sophys/common/devices/__init__.py
@@ -1,24 +1,20 @@
-from .ids import UndulatorKymaAPU
+from .aravis import AravisDetector
 from .c400 import C400, OldC400
+from .cam import CamBase_V33, Xspress3DetectorCamV33
 from .compacteras import CompactERAS
 from .crio import CRIO_9215, CRIO_9220, CRIO_9223
+from .dcm_lite import DcmLite
 from .eras import ERAS
+from .hvps import HVPS
+from .ids import UndulatorKymaAPU
 from .mobipix import Mobipix, MobipixEnergyThresholdSetter
-from .motor import (
-    ExtendedEpicsMotor,
-    ControllableMotor,
-    MotorGroup,
-)
+from .motor import ControllableMotor, ExtendedEpicsMotor, MotorGroup
+from .ocean import OceanOpticsSpectrometer
+from .picolo import Picolo, PicoloFlyScan
 from .pilatus_300k import Pilatus, PilatusWithoutHDF5
 from .pimega import Pimega, PimegaFlyScan
-from .xspress import Xspress
-from .storage_ring import StorageRing
-from .tatu import Tatu9401, Tatu9403, Tatu9401V2, TatuFlyScan
-from .dcm_lite import DcmLite
-from .picolo import Picolo, PicoloFlyScan
-from .slit import VerticalSlit, HorizontalSlit, Slit, KinematicSlit
-from .cam import CamBase_V33, Xspress3DetectorCamV33
-from .ocean import OceanOpticsSpectrometer
 from .power_pmac import PowerPmacScan
-from .aravis import AravisDetector
-from .hvps import HVPS
+from .slit import HorizontalSlit, KinematicSlit, Slit, VerticalSlit
+from .storage_ring import StorageRing
+from .tatu import Tatu9401, Tatu9401V2, Tatu9403, TatuFlyScan
+from .xspress import Xspress

--- a/src/sophys/common/devices/__init__.py
+++ b/src/sophys/common/devices/__init__.py
@@ -14,6 +14,7 @@ from .picolo import Picolo, PicoloFlyScan
 from .pilatus_300k import Pilatus, PilatusWithoutHDF5
 from .pimega import Pimega, PimegaFlyScan
 from .power_pmac import PowerPmacScan
+from .simulated import instantiate_sim_devices
 from .slit import HorizontalSlit, KinematicSlit, Slit, VerticalSlit
 from .storage_ring import StorageRing
 from .tatu import Tatu9401, Tatu9401V2, Tatu9403, TatuFlyScan

--- a/src/sophys/common/devices/simulated.py
+++ b/src/sophys/common/devices/simulated.py
@@ -1,5 +1,8 @@
 from types import SimpleNamespace
-from ophyd.sim import SynAxis, SynGauss, Syn2DGauss, SynPeriodicSignal
+
+import numpy as np
+
+from ophyd.sim import SynAxis, SynGauss, Syn2DGauss, SynPeriodicSignal, MockFlyer
 
 
 def instantiate_sim_devices():
@@ -27,6 +30,9 @@ def instantiate_sim_devices():
         sigma=1,
         noise_multiplier=0.1,
         labels={"detectors"},
+    )
+    simulated_hardware.flyer = MockFlyer(
+        "flyer", simulated_hardware.det, simulated_hardware.motor, 1, 5, 20
     )
 
     simulated_hardware.motor1 = SynAxis(name="motor1", labels={"motors"})
@@ -69,6 +75,21 @@ def instantiate_sim_devices():
         "delayed_motor2",
         center=(0, 0),
         Imax=1,
+        labels={"detectors"},
+    )
+
+    simulated_hardware.jittery_motor = SynAxis(
+        name="jittery_motor",
+        readback_func=lambda x: x + np.random.rand(),
+        labels={"motors"},
+    )
+    simulated_hardware.jittery_det = SynGauss(
+        "jittery_det",
+        simulated_hardware.jittery_motor,
+        "jittery_motor",
+        center=0,
+        Imax=1,
+        sigma=1,
         labels={"detectors"},
     )
 

--- a/src/sophys/common/devices/simulated.py
+++ b/src/sophys/common/devices/simulated.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+from ophyd.sim import SynAxis, SynGauss, Syn2DGauss, SynPeriodicSignal
+
+
+def instantiate_sim_devices():
+    """Analogue of ophyd.sim.hw, but without overlapping device names."""
+
+    simulated_hardware = SimpleNamespace()
+
+    simulated_hardware.motor = SynAxis(name="motor", labels={"motors"})
+    simulated_hardware.det = SynGauss(
+        "det",
+        simulated_hardware.motor,
+        "motor",
+        center=0,
+        Imax=1,
+        sigma=1,
+        labels={"detectors"},
+    )
+    simulated_hardware.noisy_det = SynGauss(
+        "noisy_det",
+        simulated_hardware.motor,
+        "motor",
+        center=0,
+        Imax=1,
+        noise="uniform",
+        sigma=1,
+        noise_multiplier=0.1,
+        labels={"detectors"},
+    )
+
+    simulated_hardware.motor1 = SynAxis(name="motor1", labels={"motors"})
+    simulated_hardware.motor2 = SynAxis(name="motor2", labels={"motors"})
+    simulated_hardware.det4 = Syn2DGauss(
+        "det4",
+        simulated_hardware.motor1,
+        "motor1",
+        simulated_hardware.motor2,
+        "motor2",
+        center=(0, 0),
+        Imax=1,
+        labels={"detectors"},
+    )
+
+    simulated_hardware.delayed_motor = SynAxis(
+        name="delayed_motor", labels={"motors"}, delay=5.0
+    )
+    simulated_hardware.delayed_det = SynGauss(
+        "delayed_det",
+        simulated_hardware.delayed_motor,
+        "delayed_motor",
+        center=0,
+        Imax=1,
+        sigma=1,
+        labels={"detectors"},
+    )
+
+    simulated_hardware.delayed_motor1 = SynAxis(
+        name="delayed_motor1", labels={"motors"}, delay=5.0
+    )
+    simulated_hardware.delayed_motor2 = SynAxis(
+        name="delayed_motor2", labels={"motors"}, delay=5.0
+    )
+    simulated_hardware.delayed_det4 = Syn2DGauss(
+        "delayed_det4",
+        simulated_hardware.delayed_motor1,
+        "delayed_motor1",
+        simulated_hardware.delayed_motor2,
+        "delayed_motor2",
+        center=(0, 0),
+        Imax=1,
+        labels={"detectors"},
+    )
+
+    simulated_hardware.rand = SynPeriodicSignal(name="rand", labels={"detectors"})
+    simulated_hardware.rand.start_simulation()
+    simulated_hardware.rand.kind = "hinted"
+
+    return simulated_hardware


### PR DESCRIPTION
This is very similar to `ophyd.sim.hw`, but trimmed down, and avoiding any name clashes between the devices, as they confuse `ophyd-registry` and can cause some annoying overrides.

The list of implemented devices is arbitrary, these are just the ones I care most about right now.

I had implemented this on `sophys-ema`, because the motors and detectors I needed kept being overwritten by devices with the same name, but without hints, which broke some stuff on my end. So I hope this can be useful for other people.