### PR TITLE
Update `tj-actions/changed-files` to latest version, without a security vulnerability

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-tags: true
       - name: Acquire changed files
         id: changed_files
-        uses: tj-actions/changed-files@v45.0.5
+        uses: tj-actions/changed-files@v46.0.1
       - name: Run pre-commit on the changed files
         uses: pre-commit/action@v3.0.1
         with:


### PR DESCRIPTION
This is to appease a Dependabot security warning, even though we don't hold any secrets in our CI, so this vulnerability hasn't affected us in any way.