### PR TITLE
Fix race condition in Kafka monitor tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,4 +109,7 @@ def run_engine_without_md(kafka_producer, kafka_topic):
 def good_monitor(save_queue, incomplete_documents, kafka_topic) -> ThreadedMonitor:
     mon = ThreadedMonitor(save_queue, incomplete_documents, kafka_topic, "test")
     mon.start()
+
+    mon.running.wait(timeout=2.0)
+
     return mon


### PR DESCRIPTION
I found this while studying updating our Kafka dependency back to [`kafka-python`](https://github.com/dpkp/kafka-python), as it is apparently back to life. I also lost some of my sanity in the process, evidenced by the comment on the `kafka_consumer` fixture. yay!