### PR TITLE
Fix Motor Group Device

### DIFF
--- a/src/sophys/common/devices/motor.py
+++ b/src/sophys/common/devices/motor.py
@@ -99,7 +99,7 @@ def _create_virtual_controllable_motor(components):
     return (VirtualControllableMotorClass, {"attr_keys": formattedComponents.keys()})
 
 
-def MotorGroup(prefix, motors_suffixes, name, **kwargs):
+def MotorGroup(prefix, motors_suffixes, **kwargs):
     """
     Function to instantiate several motor devices.
 
@@ -148,4 +148,4 @@ def MotorGroup(prefix, motors_suffixes, name, **kwargs):
 
     devClass = create_device_from_components(name="motor_group", **components)
 
-    return devClass(prefix=prefix, name=name, **kwargs)
+    return devClass(prefix=prefix, **kwargs)

--- a/src/sophys/common/devices/motor.py
+++ b/src/sophys/common/devices/motor.py
@@ -144,7 +144,7 @@ def MotorGroup(prefix, motors_suffixes, name, **kwargs):
             suffix = suffix[0]
             deviceClass, comp_kwargs = _create_virtual_controllable_motor(suffix[1])
 
-        components[key] = Component(deviceClass, prefix=suffix, **comp_kwargs)
+        components[key] = Component(deviceClass, suffix=suffix, **comp_kwargs)
 
     devClass = create_device_from_components(name="motor_group", **components)
 


### PR DESCRIPTION
Prefix parameter inside the MotorGroup was overriding the MotorGroup prefix.