### PR TITLE
Update external_trigger_mode to EpicsSignal for read/write access

### DIFF
--- a/src/sophys/common/devices/ocean.py
+++ b/src/sophys/common/devices/ocean.py
@@ -37,7 +37,7 @@ class OceanOpticsSpectrometer(Device):
     electrical_dark = Component(EpicsSignal, "ElectricalDark", lazy=True, string=True)
     dark_spectrum = Component(EpicsSignalRO, "GetDarkSpectrum", lazy=True, string=True)
     external_trigger_mode = Component(
-        EpicsSignalRO, "ExternalTriggerMode", lazy=True, string=True
+        EpicsSignal, "ExternalTriggerMode", lazy=True, string=True
     )
     set_external_trigger_mode = Component(
         EpicsSignalRO, "ExternalTriggerMode:Set", lazy=True


### PR DESCRIPTION
I changed the read-only (RO) mode of the PV external_trigger_mode to allow write access.