### PR TITLE
Bump minimum Python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
   "bluesky",


### PR DESCRIPTION
Follows the reasoning behind #46. Closes #46.