### PR TITLE
Fix Kinematic slits components

### DIFF
--- a/src/sophys/common/devices/slit.py
+++ b/src/sophys/common/devices/slit.py
@@ -196,13 +196,13 @@ def _create_kinematic_vertical_components(
     if top is not None:
         verticalSlitComponents.update(
             {
-                "top": Component(klass, name=f"{top}", **kwargs),
+                "top": Component(klass, top, name=f"{top}", **kwargs),
             }
         )
 
     if bottom is not None:
         verticalSlitComponents.update(
-            {"bottom": Component(klass, name=f"{bottom}", **kwargs)}
+            {"bottom": Component(klass, bottom, name=f"{bottom}", **kwargs)}
         )
 
     return verticalSlitComponents
@@ -235,13 +235,13 @@ def _create_kinematic_horizontal_components(
     if left is not None:
         horizontalSlitComponents.update(
             {
-                "left": Component(klass, name=f"{left}", **kwargs),
+                "left": Component(klass, left, name=f"{left}", **kwargs),
             }
         )
 
     if right is not None:
         horizontalSlitComponents.update(
-            {"right": Component(klass, name=f"{right}", **kwargs)}
+            {"right": Component(klass, right, name=f"{right}", **kwargs)}
         )
 
     return horizontalSlitComponents

--- a/src/sophys/common/devices/slit.py
+++ b/src/sophys/common/devices/slit.py
@@ -196,12 +196,14 @@ def _create_kinematic_vertical_components(
     if top is not None:
         verticalSlitComponents.update(
             {
-                "top": Component(klass, name=f"{top}"),
+                "top": Component(klass, name=f"{top}", **kwargs),
             }
         )
 
     if bottom is not None:
-        verticalSlitComponents.update({"bottom": Component(klass, name=f"{bottom}")})
+        verticalSlitComponents.update(
+            {"bottom": Component(klass, name=f"{bottom}", **kwargs)}
+        )
 
     return verticalSlitComponents
 
@@ -233,12 +235,14 @@ def _create_kinematic_horizontal_components(
     if left is not None:
         horizontalSlitComponents.update(
             {
-                "left": Component(klass, name=f"{left}"),
+                "left": Component(klass, name=f"{left}", **kwargs),
             }
         )
 
     if right is not None:
-        horizontalSlitComponents.update({"right": Component(klass, name=f"{right}")})
+        horizontalSlitComponents.update(
+            {"right": Component(klass, name=f"{right}", **kwargs)}
+        )
 
     return horizontalSlitComponents
 


### PR DESCRIPTION
Kinematic slits were not using `**kwargs` nor passing suffix to the component. This way, when using the slit the user would get an `TypeError` exception for the `attr_keys` that were missing from `kwargs`. As for the second problem described above, the user would get a `DisconnectedError`, since no suffix were passed to the slit component. This PR covers this two issues related with `KinematicSlit`.