### PR TITLE
Remove numpy dependency restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = ["version"]
 dependencies = [
   "bluesky",
   "ophyd",
-  "numpy==1.26.4",
+  "numpy",
   "strenum ; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
According to the merge request that introduced this change:

"Numpy version above 2.0 breaks the numpydocs package required by the Queueserver"

This is not corroborated by upstream reports, and shouldn't be a tie on this package's dependencies. Rather, if there is such an issue, it should be solved by a version tie downstream, or fixed upstream (preferably).

Closes #19