### PR TITLE
Add 'warn_on_timeout' helper function

### DIFF
--- a/src/sophys/common/utils/instantiation.py
+++ b/src/sophys/common/utils/instantiation.py
@@ -1,0 +1,39 @@
+from typing import Callable, Optional, Any
+
+from .registry import in_autoregister_context, remove_all_named
+
+
+def warn_on_timeout(
+    dev_class: type, logger: Optional[Callable[[str], Any]] = None, **kwargs
+):
+    """
+    Warn instead of throwing an Exception when timing out during object instantiation.
+
+    This calls `dev_class(**kwargs)` wrapped in an exception-handling logic.
+
+    Parameters
+    ----------
+    dev_class : type
+        The class of the object to be instantiated.
+    logger : callable, optional
+        A custom logger function to use when instantiation fails.
+        Defaults to using logging.error.
+    **kwargs : dict, optional
+        Keyword arguments to pass onto `dev_class` in instantiation.
+    """
+    if logger is None:
+        import logging
+
+        logger = logging.error
+
+    try:
+        return dev_class(**kwargs)
+    except TimeoutError as e:
+        logger(
+            f"Device '{dev_class.__name__}' with args ('{str(kwargs)}') failed to be instantiated:"
+        )
+        logger("\n".join(e.args))
+
+        # Remove broken device from registry
+        if in_autoregister_context() and "name" in kwargs:
+            remove_all_named(kwargs["name"])

--- a/tests/utils/test_instantiation.py
+++ b/tests/utils/test_instantiation.py
@@ -1,0 +1,36 @@
+import pytest
+
+import functools
+
+from ophyd import Signal, EpicsSignal
+
+from sophys.common.utils.instantiation import warn_on_timeout
+
+
+class EpicsSignalConnectingAtInstantiation(EpicsSignal):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.wait_for_connection(timeout=0.2)
+
+
+def test_warn_on_timeout():
+    log = []
+
+    def logger(s):
+        log.append(s)
+
+    _w = functools.partial(warn_on_timeout, logger=logger)
+
+    # Should not error
+    _w(Signal, name="abc")
+    assert len(log) == 0
+
+    # Should error (but not TimeoutError)
+    with pytest.raises(TypeError):
+        _w(Signal)
+    assert len(log) == 0
+
+    # Should error (with TimeoutError)
+    _w(EpicsSignalConnectingAtInstantiation, read_pv="this_pv_does_not_exist")
+    assert len(log) != 0


### PR DESCRIPTION
This is pretty useful for device instantiation on production, as some of the beamline devices may not be online all the time.

~Depends on #56~ merged