### PR TITLE
Allow specifying extra device readings in mov / rmov plans

### DIFF
--- a/src/sophys/common/plans/expanded_plan_stubs.py
+++ b/src/sophys/common/plans/expanded_plan_stubs.py
@@ -32,12 +32,19 @@ def read_many(devices, md=None):
 
 
 @parameter_annotation_decorator(_ANNOTATION)
-def mov(*args, md=None):
-    """Move many devices, and bundle their start and end positions in Bluesky documents."""
+def mov(*args, extra_device_readings=None, md=None):
+    """
+    Move many devices, and bundle their start and end positions in Bluesky documents.
+
+    You can also specify extra devices to read the value of before / after the
+    movement with the 'extra_device_readings' parameter.
+    """
 
     @bpp.run_decorator(md=md)
     def __inner():
         devices = [d for i, d in enumerate(args) if i % 2 == 0]
+        if extra_device_readings is not None:
+            devices.extend(extra_device_readings)
 
         yield from _read_many(devices)
         yield from mv(*args)
@@ -47,12 +54,19 @@ def mov(*args, md=None):
 
 
 @parameter_annotation_decorator(_ANNOTATION)
-def rmov(*args, md=None):
-    """Move many devices, and bundle their start and end positions in Bluesky documents."""
+def rmov(*args, extra_device_readings=None, md=None):
+    """
+    Move many devices, and bundle their start and end positions in Bluesky documents.
+
+    You can also specify extra devices to read the value of before / after the
+    movement with the 'extra_device_readings' parameter.
+    """
 
     @bpp.run_decorator(md=md)
     def __inner():
         devices = [d for i, d in enumerate(args) if i % 2 == 0]
+        if extra_device_readings is not None:
+            devices.extend(extra_device_readings)
 
         yield from _read_many(devices)
         yield from mvr(*args)


### PR DESCRIPTION
This is useful for derived signals and/or composite signals, which under the hoods can change other signals, and we want to read them too for user display. For instance, an `Energy` signal may change both DCM and Undulator parameters when it is set, so we may want to display these lower-level signals to users in e.g. a best-effort callback.