### PR TITLE
Add event_documents property to DocumentDictionary

### DIFF
--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -179,6 +179,15 @@ class DocumentDictionary(dict):
             else None
         )
 
+    @property
+    def event_documents(self):
+        """Return all 'event' documents (flattened from event_page if necessary)."""
+        return [
+            doc
+            for doc in self.values()
+            if isinstance(doc, dict) and doc.get("document_type") == "event"
+        ]
+
 
 class MultipleDocumentDictionary(dict):
     """


### PR DESCRIPTION
Add a simple property at `DocumentDictionary` to return all the events as a list of events. 