### PR TITLE
Improve handling of kafka offsets and capabilities of the monitor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
   "caproto!=1.2.0",
 ]
 kafka = [
-  "kafka-python-ng",
+  "kafka-python",
   "msgpack",
   "msgpack-numpy"
 ]

--- a/src/sophys/common/utils/kafka/consumer.py
+++ b/src/sophys/common/utils/kafka/consumer.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta, timezone, tzinfo
+
+from kafka import KafkaConsumer
+from kafka.consumer.fetcher import ConsumerRecord
+from kafka.structs import TopicPartition
+
+
+def seek_start_document(consumer: KafkaConsumer, record: ConsumerRecord):
+    """
+    Attempt to seek into the start document of the current run, based on data from the last received document.
+    """
+    topic_partition = TopicPartition(record.topic, record.partition)
+
+    offset = record.offset
+    event_name, event_data = record.value
+
+    beginning_offset = consumer.beginning_offsets([topic_partition])[topic_partition]
+    while event_name != "start" and offset != beginning_offset:
+        if "seq_num" in event_data:
+            offset = offset - event_data["seq_num"] - 1
+        else:
+            offset -= 1
+        consumer.seek(topic_partition, offset)
+
+        records = consumer.poll(timeout_ms=5_000, max_records=1, update_offsets=False)
+        assert (
+            topic_partition in records
+        ), "Could not retrieve data from Kafka in seek_start."
+
+        event_name, event_data = records[topic_partition][0].value
+
+
+def seek_back_in_time(
+    consumer: KafkaConsumer,
+    rewind_time: timedelta,
+    server_timezone: tzinfo = timezone.utc,
+):
+    """
+    Rewind the consumer by 'rewind_time', up to the beginning offset.
+    """
+    now = datetime.now(server_timezone)
+
+    all_partitions = [
+        TopicPartition(topic_name, p)
+        for topic_name in consumer.subscription()
+        for p in consumer.partitions_for_topic(topic_name)
+    ]
+
+    # NOTE: offsets_for_times expects timestamps in ms, so we multiply by 1000.
+    rewind_timestamp = int((now - rewind_time).timestamp() * 1000)
+    timestamp_offsets = consumer.offsets_for_times(
+        {p: rewind_timestamp for p in all_partitions}
+    )
+
+    for partition, offset_ts in timestamp_offsets.items():
+        if offset_ts is not None:
+            consumer.seek(partition, offset_ts.offset)

--- a/src/sophys/common/utils/kafka/consumer.py
+++ b/src/sophys/common/utils/kafka/consumer.py
@@ -22,10 +22,19 @@ def seek_start_document(consumer: KafkaConsumer, record: ConsumerRecord):
             offset -= 1
         consumer.seek(topic_partition, offset)
 
-        records = consumer.poll(timeout_ms=5_000, max_records=1, update_offsets=False)
-        assert (
-            topic_partition in records
-        ), "Could not retrieve data from Kafka in seek_start."
+        for attempt_number in range(1, 4):
+            timeout = 1_000 * attempt_number
+            records = consumer.poll(
+                timeout_ms=timeout, max_records=1, update_offsets=False
+            )
+
+            if topic_partition in records:
+                break
+
+        if topic_partition not in records:
+            raise RuntimeError(
+                f"Failed to retrieve records for the current partition ('{record.partition}' for '{record.topic}')"
+            )
 
         event_name, event_data = records[topic_partition][0].value
 

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -401,10 +401,13 @@ class MonitorBase(KafkaConsumer):
                 return
 
             if data[0] == "start":
-                self._logger.info("Received a 'start' document.")
-
                 self.__documents.append(data)
+
                 new_run_uid = self.__documents[data].identifier
+                self._logger.info(
+                    "Run '{}': Received a 'start' document.".format(new_run_uid)
+                )
+
                 self.__incomplete_documents.append(new_run_uid)
 
                 self.__documents[data].subscribe(

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -361,6 +361,22 @@ class MonitorBase(KafkaConsumer):
         """Get the name of the Kafka topic monitored by this object."""
         return "".join(self.subscription())
 
+    def _seek_start_if_needed(self, event) -> bool:
+        should_seek_start = False
+
+        try:
+            if event.value[0] != "start" and len(self.__documents[event.value]) == 0:
+                # In the middle of a run, try to go back to the beginning
+                should_seek_start = True
+        except KeyError:
+            # In the middle of a run, try to go back to the beginning
+            should_seek_start = True
+
+        if should_seek_start:
+            seek_start(self, event.topic, event.partition, event.offset, *event.value)
+
+        return should_seek_start
+
     def _commit_pending_documents(self):
         """Commit pending documents to the save queue, when possible."""
         if self.__save_queue is None:
@@ -406,64 +422,50 @@ class MonitorBase(KafkaConsumer):
                 if id in self.__to_save_documents_save_attempts:
                     del self.__to_save_documents_save_attempts[id]
 
-    def handle_event(self, event):
-        self._logger.debug("Event received.")
-
-        should_seek_start = False
+    def _handle_kafka_event(self, event):
+        data = event.value
+        if len(data) != 2:
+            self._logger.warning(
+                "Event data does not have two elements.\n {}".format(str(data))
+            )
+            return
 
         try:
-            data = event.value
-
-            if len(data) != 2:
-                self._logger.warning(
-                    "Event data does not have two elements.\n {}".format(str(data))
-                )
+            if self._seek_start_if_needed(event):
                 return
 
-            if data[0] == "start":
-                self.__documents.append(data)
+            match data:
+                case ("start", _):
+                    self.__documents.append(data)
 
-                new_run_uid = self.__documents[data].identifier
-                self._logger.info(
-                    "Run '{}': Received a 'start' document.".format(new_run_uid)
-                )
-
-                self.__incomplete_documents.append(new_run_uid)
-
-                self.__documents[data].subscribe(
-                    partial(self._run_subscriptions, new_run_uid)
-                )
-
-                return
-
-            try:
-                if len(self.__documents[data]) == 0:
-                    # In the middle of a run, try to go back to the beginning
-                    should_seek_start = True
-            except KeyError:
-                # In the middle of a run, try to go back to the beginning
-                should_seek_start = True
-
-            if should_seek_start:
-                seek_start(self, event.topic, event.partition, event.offset, *data)
-                return
-
-            self.__documents[data].append(*data)
-
-            if data[0] == "stop":
-                self._logger.info(
-                    "Run '{}': Received a 'stop' document.".format(
-                        self.__documents[data].identifier
+                    new_run_uid = self.__documents[data].identifier
+                    self._logger.info(
+                        "Run '{}': Received a 'start' document.".format(new_run_uid)
                     )
-                )
 
-                self.__documents[data].clear_subscriptions()
-                self.__to_save_documents.append(self.__documents[data].identifier)
+                    self.__incomplete_documents.append(new_run_uid)
 
-                # TODO: Validate number of saved entries via the stop document's num_events
-                # TODO: Validate successful run via the stop document's exit_status
+                    self.__documents[data].subscribe(
+                        partial(self._run_subscriptions, new_run_uid)
+                    )
+                case ("stop", _):
+                    self._logger.info(
+                        "Run '{}': Received a 'stop' document.".format(
+                            self.__documents[data].identifier
+                        )
+                    )
 
-                self._commit_pending_documents()
+                    self.__documents[data].append(*data)
+
+                    self.__documents[data].clear_subscriptions()
+                    self.__to_save_documents.append(self.__documents[data].identifier)
+
+                    # TODO: Validate number of saved entries via the stop document's num_events
+                    # TODO: Validate successful run via the stop document's exit_status
+
+                    self._commit_pending_documents()
+                case (_, _):
+                    self.__documents[data].append(*data)
 
         except Exception as e:
             self._logger.error("Unhandled exception. Will try to continue regardless.")
@@ -475,15 +477,17 @@ class MonitorBase(KafkaConsumer):
 
     def run(self):
         """Start monitoring the Kafka topic."""
-        partition_number = list(self.partitions_for_topic(self.topic()))[0]
-        self._update_fetch_positions([TopicPartition(self.topic(), partition_number)])
+        # NOTE: Configure the current offset before setting the 'running' flag.
+        #     The timeout time here doesn't matter too much, as we don't care
+        #     whether we received new data or not.
+        self.poll(timeout_ms=100, max_records=1, update_offsets=False)
 
         self.running.set()
         while not self._closed:
             try:
                 for event in self:
-                    self.handle_event(event)
-            except StopIteration:
+                    self._handle_kafka_event(event)
+            except (StopIteration, AssertionError):
                 pass
 
         self.running.clear()

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -1,7 +1,7 @@
 import logging
 import json
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone, tzinfo
+from datetime import timedelta
 from functools import wraps, partial
 from typing import Optional
 
@@ -11,9 +11,10 @@ from queue import Full as QueueFullException, Queue
 import msgpack_numpy as _m
 
 from kafka import KafkaConsumer
-from kafka.structs import TopicPartition
 
 from event_model import EventPage, unpack_event_page
+
+from .consumer import seek_start_document, seek_back_in_time
 
 
 def _get_uid_from_event_data(event_data: dict):
@@ -35,60 +36,6 @@ def _get_descriptor_uid_from_event_data(event_data: dict):
 def _get_start_uid_from_event_data(event_data: dict):
     # TODO: Deal with non stop documents.
     return event_data.get("run_start", None)
-
-
-def seek_start(
-    consumer: KafkaConsumer,
-    topic: str,
-    partition_id: int,
-    offset: int,
-    event_name: str,
-    event_data: dict,
-) -> int:
-    """Attempt to seek into the start document of the current run."""
-    topic_partition = TopicPartition(topic, partition_id)
-
-    beginning_offset = consumer.beginning_offsets([topic_partition])[topic_partition]
-    while event_name != "start" and offset != beginning_offset:
-        if "seq_num" in event_data:
-            offset = offset - event_data["seq_num"] - 1
-        else:
-            offset -= 1
-        consumer.seek(topic_partition, offset)
-
-        records = consumer.poll(timeout_ms=5_000, max_records=1, update_offsets=False)
-        assert (
-            topic_partition in records
-        ), "Could not retrieve data from Kafka in seek_start."
-
-        event_name, event_data = records[topic_partition][0].value
-
-    return offset
-
-
-def seek_back_in_time(
-    consumer: KafkaConsumer,
-    rewind_time: timedelta,
-    server_timezone: tzinfo = timezone.utc,
-):
-    """Rewind the consumer by 'rewind_time'."""
-    now = datetime.now(server_timezone)
-
-    all_partitions = [
-        TopicPartition(topic_name, p)
-        for topic_name in consumer.subscription()
-        for p in consumer.partitions_for_topic(topic_name)
-    ]
-
-    # NOTE: offsets_for_times expects timestamps in ms, so we multiply by 1000.
-    rewind_timestamp = int((now - rewind_time).timestamp() * 1000)
-    timestamp_offsets = consumer.offsets_for_times(
-        {p: rewind_timestamp for p in all_partitions}
-    )
-
-    for partition, offset_ts in timestamp_offsets.items():
-        if offset_ts is not None:
-            consumer.seek(partition, offset_ts.offset)
 
 
 class DocumentDictionary(dict):
@@ -404,7 +351,7 @@ class MonitorBase(KafkaConsumer):
             should_seek_start = True
 
         if should_seek_start:
-            seek_start(self, event.topic, event.partition, event.offset, *event.value)
+            seek_start_document(self, event)
 
         return should_seek_start
 

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -321,6 +321,7 @@ class MonitorBase(KafkaConsumer):
         incomplete_documents: list,
         topic_name: str,
         logger_name: str,
+        hour_offset: Optional[float] = None,
         **configs,
     ):
         """
@@ -337,6 +338,8 @@ class MonitorBase(KafkaConsumer):
             The Kafka topic to monitor.
         logger_name : str, optional
             Name of the logger to use for info / debug during the monitor processing.
+        hour_offset : float, optional
+            Time in hours to look back in Kafka right after the start of monitoring.
         **configs : dict or keyword arguments
             Extra arguments to pass to the KafkaConsumer's constructor.
         """
@@ -344,6 +347,8 @@ class MonitorBase(KafkaConsumer):
 
         self.name = repr(self)
         self.running = Event()
+
+        self.__hour_offset = hour_offset
 
         self.__documents = MultipleDocumentDictionary()
         self.__save_queue = save_queue
@@ -507,6 +512,9 @@ class MonitorBase(KafkaConsumer):
         #     The timeout time here doesn't matter too much, as we don't care
         #     whether we received new data or not.
         self.poll(timeout_ms=100, max_records=1, update_offsets=False)
+
+        if self.__hour_offset is not None:
+            seek_back_in_time(self, timedelta(hours=self.__hour_offset))
 
         self.running.set()
         while not self._closed:

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -1,6 +1,7 @@
 import logging
 import json
 from collections import defaultdict
+from datetime import datetime, timedelta, timezone, tzinfo
 from functools import wraps, partial
 from typing import Optional
 
@@ -63,6 +64,31 @@ def seek_start(
         event_name, event_data = records[topic_partition][0].value
 
     return offset
+
+
+def seek_back_in_time(
+    consumer: KafkaConsumer,
+    rewind_time: timedelta,
+    server_timezone: tzinfo = timezone.utc,
+):
+    """Rewind the consumer by 'rewind_time'."""
+    now = datetime.now(server_timezone)
+
+    all_partitions = [
+        TopicPartition(topic_name, p)
+        for topic_name in consumer.subscription()
+        for p in consumer.partitions_for_topic(topic_name)
+    ]
+
+    # NOTE: offsets_for_times expects timestamps in ms, so we multiply by 1000.
+    rewind_timestamp = int((now - rewind_time).timestamp() * 1000)
+    timestamp_offsets = consumer.offsets_for_times(
+        {p: rewind_timestamp for p in all_partitions}
+    )
+
+    for partition, offset_ts in timestamp_offsets.items():
+        if offset_ts is not None:
+            consumer.seek(partition, offset_ts.offset)
 
 
 class DocumentDictionary(dict):

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -62,9 +62,6 @@ def seek_start(
 
         event_name, event_data = records[topic_partition][0].value
 
-    if consumer.position(topic_partition) != offset:
-        consumer.seek(topic_partition, offset)
-
     return offset
 
 

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -377,11 +377,16 @@ class MonitorBase(KafkaConsumer):
                     self.__save_queue.put(doc, block=True, timeout=1.0)
                     self.__saved_document_uids.add(id)
                 except Exception as e:
-                    self._logger.error(
-                        "Unhandled exception while trying to save documents. Will try to continue regardless."
-                    )
-                    self._logger.error("Exception if you're into that:")
-                    self._logger.exception(e)
+                    if isinstance(e, QueueFullException):
+                        self._logger.warning(
+                            "Save queue is full. Failed to add run '%s'.", id
+                        )
+                    else:
+                        self._logger.error(
+                            "Unhandled exception while trying to save documents. Will try to continue regardless."
+                        )
+                        self._logger.error("Exception if you're into that:")
+                        self._logger.exception(e)
 
                     self.__to_save_documents_save_attempts[id] += 1
 

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -36,6 +36,38 @@ def _get_start_uid_from_event_data(event_data: dict):
     return event_data.get("run_start", None)
 
 
+def seek_start(
+    consumer: KafkaConsumer,
+    topic: str,
+    partition_id: int,
+    offset: int,
+    event_name: str,
+    event_data: dict,
+) -> int:
+    """Attempt to seek into the start document of the current run."""
+    topic_partition = TopicPartition(topic, partition_id)
+
+    beginning_offset = consumer.beginning_offsets([topic_partition])[topic_partition]
+    while event_name != "start" and offset != beginning_offset:
+        if "seq_num" in event_data:
+            offset = offset - event_data["seq_num"] - 1
+        else:
+            offset -= 1
+        consumer.seek(topic_partition, offset)
+
+        records = consumer.poll(timeout_ms=5_000, max_records=1, update_offsets=False)
+        assert (
+            topic_partition in records
+        ), "Could not retrieve data from Kafka in seek_start."
+
+        event_name, event_data = records[topic_partition][0].value
+
+    if consumer.position(topic_partition) != offset:
+        consumer.seek(topic_partition, offset)
+
+    return offset
+
+
 class DocumentDictionary(dict):
     """Auxiliary class for accumulating Document entries."""
 
@@ -332,20 +364,6 @@ class MonitorBase(KafkaConsumer):
         """Get the name of the Kafka topic monitored by this object."""
         return "".join(self.subscription())
 
-    def seek_start(
-        self, topic: str, partition_id: int, offset: int, event_data: dict
-    ) -> None:
-        """Attempt to seek into the start document of the current run. May not seek if the current event does not have a sequence number."""
-        if "seq_num" not in event_data:
-            self._logger.debug(
-                "Sequence numbers are not available! o.O\n {}".format(str(event_data))
-            )
-            # Hopefully a future event will have it!
-            return
-        self.seek(
-            TopicPartition(topic, partition_id), offset - event_data["seq_num"] - 1
-        )
-
     def _commit_pending_documents(self):
         """Commit pending documents to the save queue, when possible."""
         if self.__save_queue is None:
@@ -389,7 +407,7 @@ class MonitorBase(KafkaConsumer):
     def handle_event(self, event):
         self._logger.debug("Event received.")
 
-        seek_start = False
+        should_seek_start = False
 
         try:
             data = event.value
@@ -419,13 +437,13 @@ class MonitorBase(KafkaConsumer):
             try:
                 if len(self.__documents[data]) == 0:
                     # In the middle of a run, try to go back to the beginning
-                    seek_start = True
+                    should_seek_start = True
             except KeyError:
                 # In the middle of a run, try to go back to the beginning
-                seek_start = True
+                should_seek_start = True
 
-            if seek_start:
-                self.seek_start(event.topic, event.partition, event.offset, data[1])
+            if should_seek_start:
+                seek_start(self, event.topic, event.partition, event.offset, *data)
                 return
 
             self.__documents[data].append(*data)

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -1,3 +1,4 @@
+import enum
 import logging
 import json
 from collections import defaultdict
@@ -261,6 +262,12 @@ class MultipleDocumentDictionary(dict):
             return super().__getitem__(self.find_with_resource(resource_uid))
 
 
+class SeekStartResult(enum.Enum):
+    NO_SEEK = enum.auto()
+    SEEK_SUCCEEDED = enum.auto()
+    SEEK_FAILED = enum.auto()
+
+
 class MonitorBase(KafkaConsumer):
     def __init__(
         self,
@@ -294,6 +301,8 @@ class MonitorBase(KafkaConsumer):
 
         self.name = repr(self)
         self.running = Event()
+
+        self._runs_to_ignore = set()
 
         self.__hour_offset = hour_offset
 
@@ -339,7 +348,7 @@ class MonitorBase(KafkaConsumer):
         """Get the name of the Kafka topic monitored by this object."""
         return "".join(self.subscription())
 
-    def _seek_start_if_needed(self, event) -> bool:
+    def _seek_start_if_needed(self, event) -> SeekStartResult:
         should_seek_start = False
 
         try:
@@ -350,10 +359,19 @@ class MonitorBase(KafkaConsumer):
             # In the middle of a run, try to go back to the beginning
             should_seek_start = True
 
+        seek_start_succeeded = True
         if should_seek_start:
-            seek_start_document(self, event)
+            try:
+                seek_start_document(self, event)
+            except RuntimeError:
+                self._logger.error("Run '{}': {}", event)
+                seek_start_succeeded = False
 
-        return should_seek_start
+        if not should_seek_start:
+            return SeekStartResult.NO_SEEK
+        if not seek_start_succeeded:
+            return SeekStartResult.SEEK_FAILED
+        return SeekStartResult.SEEK_SUCCEEDED
 
     def _commit_pending_documents(self):
         """Commit pending documents to the save queue, when possible."""
@@ -409,7 +427,19 @@ class MonitorBase(KafkaConsumer):
             return
 
         try:
-            if self._seek_start_if_needed(event):
+            match self._seek_start_if_needed(event):
+                case SeekStartResult.NO_SEEK:
+                    pass
+                case SeekStartResult.SEEK_SUCCEEDED:
+                    return
+                case SeekStartResult.SEEK_FAILED:
+                    start_uid = _get_start_uid_from_event_data(data[1])
+                    if start_uid is not None:
+                        self._runs_to_ignore.add(start_uid)
+                    return
+
+            start_uid = _get_start_uid_from_event_data(data[1])
+            if start_uid in self._runs_to_ignore:
                 return
 
             match data:
@@ -437,6 +467,9 @@ class MonitorBase(KafkaConsumer):
 
                     self.__documents[data].clear_subscriptions()
                     self.__to_save_documents.append(self.__documents[data].identifier)
+
+                    start_uid = self.__documents[data].identifier
+                    self._runs_to_ignore.discard(start_uid)
 
                     # TODO: Validate number of saved entries via the stop document's num_events
                     # TODO: Validate successful run via the stop document's exit_status

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,11 @@
 import pytest
 
+import msgpack_numpy as msgpack
+
+from kafka import KafkaConsumer, KafkaProducer
+
+from bluesky import RunEngine
+
 from .soft_ioc import start_soft_ioc
 
 
@@ -8,3 +14,44 @@ def soft_ioc():
     soft_ioc_prefix, stop_soft_ioc = start_soft_ioc()
     yield soft_ioc_prefix
     stop_soft_ioc()
+
+
+@pytest.fixture(scope="session")
+def kafka_bootstrap_ip():
+    return "localhost:9092"
+
+
+@pytest.fixture(scope="session")
+def kafka_topic():
+    return "test_bluesky_raw_docs"
+
+
+@pytest.fixture(scope="function")
+def kafka_producer(kafka_bootstrap_ip):
+    producer = KafkaProducer(
+        bootstrap_servers=[kafka_bootstrap_ip], value_serializer=msgpack.dumps
+    )
+    yield producer
+    producer.flush()
+    producer.close()
+
+
+@pytest.fixture(scope="function")
+def kafka_consumer(kafka_bootstrap_ip, kafka_topic):
+    consumer = KafkaConsumer(
+        kafka_topic,
+        bootstrap_servers=[kafka_bootstrap_ip],
+        value_deserializer=msgpack.unpackb,
+    )
+
+    # Connect the consumer properly to the topic
+    consumer.poll(timeout_ms=100, max_records=1, update_offsets=False)
+
+    return consumer
+
+
+@pytest.fixture(scope="function")
+def run_engine_without_md(kafka_producer, kafka_topic):
+    RE = RunEngine()
+    RE.subscribe(lambda name, doc: kafka_producer.send(kafka_topic, (name, doc)))
+    return RE

--- a/tests/utils/test_kafka_consumer.py
+++ b/tests/utils/test_kafka_consumer.py
@@ -1,0 +1,110 @@
+from datetime import datetime, timezone
+
+from kafka.producer import KafkaProducer
+from kafka.consumer import KafkaConsumer
+from kafka.structs import TopicPartition
+
+import numpy as np
+
+from ophyd.sim import hw
+from bluesky import plans as bp
+
+from sophys.common.utils.kafka.monitor import seek_start_document, seek_back_in_time
+
+
+def test_seek_start(
+    kafka_producer: KafkaProducer,
+    kafka_consumer: KafkaConsumer,
+    kafka_topic,
+    run_engine_without_md,
+):
+    partition_number = list(kafka_consumer.partitions_for_topic(kafka_topic))[0]
+    topic_partition = TopicPartition(kafka_topic, partition_number)
+    original_offset = kafka_consumer.position(topic_partition)
+
+    uid, *_ = run_engine_without_md(bp.count([hw().det], num=10))
+
+    def seek_and_assert_positions(offset: int, seeked_event_name: str):
+        kafka_consumer.seek(topic_partition, offset)
+
+        record = kafka_consumer.poll(
+            timeout_ms=1_000, max_records=1, update_offsets=False
+        )[topic_partition][0]
+
+        event_name, _ = record.value
+        assert event_name == seeked_event_name
+
+        seek_start_document(kafka_consumer, record)
+
+        record = kafka_consumer.poll(
+            timeout_ms=1_000, max_records=1, update_offsets=False
+        )[topic_partition][0]
+
+        event_name, _ = record.value
+        assert event_name == "start"
+
+    kafka_producer.flush(timeout=1.0)
+    while kafka_consumer.poll(timeout_ms=100) != {}:
+        pass
+
+    new_offset = kafka_consumer.position(topic_partition)
+    # start (1) + descriptor (1) + events (10) + stop (1)
+    assert new_offset - original_offset == 13
+
+    # From stop to start
+    seek_and_assert_positions(new_offset - 1, "stop")
+
+    # From start to start (do nothing)
+    seek_and_assert_positions(original_offset, "start")
+
+    # From event in the middle to start
+    seek_and_assert_positions(original_offset + 5, "event")
+
+    # From descriptor to start
+    seek_and_assert_positions(original_offset + 1, "descriptor")
+
+
+def test_seek_back_in_time(
+    kafka_producer: KafkaProducer,
+    kafka_consumer: KafkaConsumer,
+    kafka_topic,
+    run_engine_without_md,
+):
+    partition_number = list(kafka_consumer.partitions_for_topic(kafka_topic))[0]
+    topic_partition = TopicPartition(kafka_topic, partition_number)
+
+    kafka_consumer.seek_to_beginning()
+    oldest_offset = kafka_consumer.position(topic_partition)
+
+    kafka_consumer.seek_to_end()
+    newest_offset = kafka_consumer.position(topic_partition)
+
+    if newest_offset - oldest_offset < 5:
+        # Add some new time-spaced data.
+        for _ in range(5):
+            run_engine_without_md(bp.count([hw().det], num=2, delay=1))
+        while kafka_consumer.poll(timeout_ms=100) != {}:
+            pass
+        newest_offset = kafka_consumer.position(topic_partition)
+
+    offsets = [round(x) for x in np.linspace(oldest_offset, newest_offset - 1, num=5)]
+    timestamps = list()
+    for offset in offsets:
+        kafka_consumer.seek(topic_partition, offset)
+
+        record = kafka_consumer.poll(
+            timeout_ms=1_000, max_records=1, update_offsets=False
+        )[topic_partition][0]
+        timestamps.append(record.timestamp // 1000)
+
+    for expected_timestamp in timestamps:
+        time_delta = datetime.now(timezone.utc) - datetime.fromtimestamp(
+            expected_timestamp, tz=timezone.utc
+        )
+        seek_back_in_time(kafka_consumer, time_delta)
+
+        record = kafka_consumer.poll(
+            timeout_ms=1_000, max_records=1, update_offsets=False
+        )[topic_partition][0]
+
+        assert np.isclose(record.timestamp // 1000, expected_timestamp, atol=1)

--- a/tests/utils/test_kafka_monitor.py
+++ b/tests/utils/test_kafka_monitor.py
@@ -376,52 +376,53 @@ def test_seek_start(kafka_producer, kafka_consumer, kafka_topic, run_engine_with
     _hw = hw()
     det = _hw.det
 
+    uid, *_ = run_engine_without_md(bp.count([det], num=10))
+
     partition_number = list(kafka_consumer.partitions_for_topic(kafka_topic))[0]
     topic_partition = TopicPartition(kafka_topic, partition_number)
     original_offset = kafka_consumer.position(topic_partition)
 
-    uid, *_ = run_engine_without_md(bp.count([det], num=10))
+    def seek_and_assert_positions(offset: int, seeked_event_name: str):
+        kafka_consumer.seek(topic_partition, offset)
 
-    kafka_producer.flush(timeout=5.0)
-    kafka_consumer.poll(timeout_ms=5_000)
+        records = kafka_consumer.poll(
+            timeout_ms=1_000, max_records=1, update_offsets=False
+        )
+        event_name, event_data = records[topic_partition][0].value
+
+        assert event_name == seeked_event_name
+
+        seek_start(
+            kafka_consumer,
+            kafka_topic,
+            partition_number,
+            offset,
+            event_name,
+            event_data,
+        )
+
+        records = kafka_consumer.poll(
+            timeout_ms=1_000, max_records=1, update_offsets=False
+        )
+        event_name, _ = records[topic_partition][0].value
+
+        assert event_name == "start"
+
+    kafka_producer.flush(timeout=1.0)
+    kafka_consumer.poll(timeout_ms=1_000)
 
     new_offset = kafka_consumer.position(topic_partition)
     # start (1) + descriptor (1) + events (10) + stop (1)
     assert new_offset - original_offset == 13
 
     # From stop to start
-    new_offset = seek_start(
-        kafka_consumer, kafka_topic, partition_number, new_offset, "stop", {}
-    )
-    assert kafka_consumer.position(topic_partition) == new_offset
-    assert new_offset == original_offset
-
-    # From event in the middle to start
-    kafka_consumer.seek(topic_partition, original_offset + 5)
-    records = kafka_consumer.poll(timeout_ms=5_000, max_records=1)
-    new_offset = seek_start(
-        kafka_consumer,
-        kafka_topic,
-        partition_number,
-        original_offset + 5,
-        *records[topic_partition][0].value,
-    )
-    assert kafka_consumer.position(topic_partition) == new_offset
-    assert new_offset == original_offset
+    seek_and_assert_positions(new_offset - 1, "stop")
 
     # From start to start (do nothing)
-    records = kafka_consumer.poll(timeout_ms=5_000, max_records=1)
-    if topic_partition not in records:
-        # NOTE: This test won't work for kafka-python-ng,
-        # which doesn't return the correct thing here.
-        return
+    seek_and_assert_positions(original_offset, "start")
 
-    new_offset = seek_start(
-        kafka_consumer,
-        kafka_topic,
-        partition_number,
-        original_offset,
-        *records[topic_partition][0].value,
-    )
-    assert kafka_consumer.position(topic_partition) == new_offset
-    assert new_offset == original_offset
+    # From event in the middle to start
+    seek_and_assert_positions(original_offset + 5, "event")
+
+    # From descriptor to start
+    seek_and_assert_positions(original_offset + 1, "descriptor")

--- a/tests/utils/test_kafka_monitor.py
+++ b/tests/utils/test_kafka_monitor.py
@@ -15,6 +15,8 @@ from bluesky import RunEngine, plans as bp, plan_stubs as bps, preprocessors as 
 
 from sophys.common.utils.kafka.monitor import ThreadedMonitor
 
+from sophys.common.utils.kafka.monitor import seek_start
+
 from . import _wait
 
 
@@ -368,3 +370,53 @@ def test_basic_custom_plan_with_two_nested_runs(
 
     # One start doc, one descriptor doc, one event doc, one stop doc
     assert len(docs) == 4, docs.get_raw_data()
+
+
+def test_seek_start(kafka_producer, kafka_consumer, kafka_topic, run_engine_without_md):
+    _hw = hw()
+    det = _hw.det
+
+    partition_number = list(kafka_consumer.partitions_for_topic(kafka_topic))[0]
+    topic_partition = TopicPartition(kafka_topic, partition_number)
+    original_offset = kafka_consumer.position(topic_partition)
+
+    uid, *_ = run_engine_without_md(bp.count([det], num=10))
+
+    kafka_producer.flush(timeout=5.0)
+    kafka_consumer.poll(timeout_ms=5_000)
+
+    new_offset = kafka_consumer.position(topic_partition)
+    # start (1) + descriptor (1) + events (10) + stop (1)
+    assert new_offset - original_offset == 13
+
+    # From stop to start
+    new_offset = seek_start(
+        kafka_consumer, kafka_topic, partition_number, new_offset, "stop", {}
+    )
+    assert kafka_consumer.position(topic_partition) == new_offset
+    assert new_offset == original_offset
+
+    # From event in the middle to start
+    kafka_consumer.seek(topic_partition, original_offset + 5)
+    records = kafka_consumer.poll(timeout_ms=5_000, max_records=1)
+    new_offset = seek_start(
+        kafka_consumer,
+        kafka_topic,
+        partition_number,
+        original_offset + 5,
+        *records[topic_partition][0].value,
+    )
+    assert kafka_consumer.position(topic_partition) == new_offset
+    assert new_offset == original_offset
+
+    # From start to start (do nothing)
+    records = kafka_consumer.poll(timeout_ms=5_000, max_records=1)
+    new_offset = seek_start(
+        kafka_consumer,
+        kafka_topic,
+        partition_number,
+        original_offset,
+        *records[topic_partition][0].value,
+    )
+    assert kafka_consumer.position(topic_partition) == new_offset
+    assert new_offset == original_offset

--- a/tests/utils/test_kafka_monitor.py
+++ b/tests/utils/test_kafka_monitor.py
@@ -1,7 +1,7 @@
 import pytest
 
 import queue
-import time
+from datetime import datetime, timezone
 
 import msgpack
 import msgpack_numpy as _m
@@ -10,12 +10,14 @@ from kafka.producer import KafkaProducer
 from kafka.consumer import KafkaConsumer
 from kafka.structs import TopicPartition
 
+import numpy as np
+
 from ophyd.sim import hw
 from bluesky import RunEngine, plans as bp, plan_stubs as bps, preprocessors as bpp
 
 from sophys.common.utils.kafka.monitor import ThreadedMonitor
 
-from sophys.common.utils.kafka.monitor import seek_start
+from sophys.common.utils.kafka.monitor import seek_start, seek_back_in_time
 
 from . import _wait
 
@@ -95,17 +97,13 @@ def kafka_producer(kafka_bootstrap_ip):
 @pytest.fixture(scope="function")
 def kafka_consumer(kafka_bootstrap_ip, kafka_topic):
     consumer = KafkaConsumer(
-        bootstrap_servers=[kafka_bootstrap_ip], value_deserializer=msgpack.unpackb
+        kafka_topic,
+        bootstrap_servers=[kafka_bootstrap_ip],
+        value_deserializer=msgpack.unpackb,
     )
 
     # Connect the consumer properly to the topic
-    partition = TopicPartition(kafka_topic, 0)
-    consumer.assign([partition])
-    print("Starting offset:")
-    # Fun fact: this is actually required for the tests to work properly,
-    # because otherwise it doesn't update the current offset before the
-    # producer starts throwing events at the topic. :)))))
-    print(consumer.position(partition))
+    consumer.poll(timeout_ms=100, max_records=1, update_offsets=False)
 
     return consumer
 
@@ -380,15 +378,14 @@ def test_basic_custom_plan_with_two_nested_runs(
     assert len(docs) == 4, docs.get_raw_data()
 
 
-def test_seek_start(kafka_producer, kafka_consumer, kafka_topic, run_engine_without_md):
-    _hw = hw()
-    det = _hw.det
-
-    uid, *_ = run_engine_without_md(bp.count([det], num=10))
-
+def test_seek_start(
+    kafka_producer, kafka_consumer: KafkaConsumer, kafka_topic, run_engine_without_md
+):
     partition_number = list(kafka_consumer.partitions_for_topic(kafka_topic))[0]
     topic_partition = TopicPartition(kafka_topic, partition_number)
     original_offset = kafka_consumer.position(topic_partition)
+
+    uid, *_ = run_engine_without_md(bp.count([hw().det], num=10))
 
     def seek_and_assert_positions(offset: int, seeked_event_name: str):
         kafka_consumer.seek(topic_partition, offset)
@@ -417,7 +414,8 @@ def test_seek_start(kafka_producer, kafka_consumer, kafka_topic, run_engine_with
         assert event_name == "start"
 
     kafka_producer.flush(timeout=1.0)
-    kafka_consumer.poll(timeout_ms=1_000)
+    while kafka_consumer.poll(timeout_ms=100) != {}:
+        pass
 
     new_offset = kafka_consumer.position(topic_partition)
     # start (1) + descriptor (1) + events (10) + stop (1)
@@ -478,3 +476,46 @@ def test_seek_start_in_monitor(
         )
 
     run_engine_without_md(custom_plan())
+
+
+def test_seek_back_in_time(
+    kafka_producer, kafka_consumer: KafkaConsumer, kafka_topic, run_engine_without_md
+):
+    partition_number = list(kafka_consumer.partitions_for_topic(kafka_topic))[0]
+    topic_partition = TopicPartition(kafka_topic, partition_number)
+
+    kafka_consumer.seek_to_beginning()
+    oldest_offset = kafka_consumer.position(topic_partition)
+
+    kafka_consumer.seek_to_end()
+    newest_offset = kafka_consumer.position(topic_partition)
+
+    if newest_offset - oldest_offset < 5:
+        # Add some new time-spaced data.
+        for _ in range(5):
+            run_engine_without_md(bp.count([hw().det], num=2, delay=1))
+        while kafka_consumer.poll(timeout_ms=100) != {}:
+            pass
+        newest_offset = kafka_consumer.position(topic_partition)
+
+    offsets = [round(x) for x in np.linspace(oldest_offset, newest_offset - 1, num=5)]
+    timestamps = list()
+    for offset in offsets:
+        kafka_consumer.seek(topic_partition, offset)
+
+        record = kafka_consumer.poll(
+            timeout_ms=1_000, max_records=1, update_offsets=False
+        )[topic_partition][0]
+        timestamps.append(record.timestamp // 1000)
+
+    for expected_timestamp in timestamps:
+        time_delta = datetime.now(timezone.utc) - datetime.fromtimestamp(
+            expected_timestamp, tz=timezone.utc
+        )
+        seek_back_in_time(kafka_consumer, time_delta)
+
+        record = kafka_consumer.poll(
+            timeout_ms=1_000, max_records=1, update_offsets=False
+        )[topic_partition][0]
+
+        assert np.isclose(record.timestamp // 1000, expected_timestamp, atol=1)

--- a/tests/utils/test_kafka_monitor.py
+++ b/tests/utils/test_kafka_monitor.py
@@ -411,6 +411,11 @@ def test_seek_start(kafka_producer, kafka_consumer, kafka_topic, run_engine_with
 
     # From start to start (do nothing)
     records = kafka_consumer.poll(timeout_ms=5_000, max_records=1)
+    if topic_partition not in records:
+        # NOTE: This test won't work for kafka-python-ng,
+        # which doesn't return the correct thing here.
+        return
+
     new_offset = seek_start(
         kafka_consumer,
         kafka_topic,

--- a/tests/utils/test_kafka_monitor.py
+++ b/tests/utils/test_kafka_monitor.py
@@ -132,8 +132,7 @@ def run_engine_without_md(kafka_producer, kafka_topic):
     return RE
 
 
-@pytest.fixture(scope="function")
-def good_monitor(
+def _create_good_monitor(
     save_queue, incomplete_documents, kafka_topic, kafka_bootstrap_ip
 ) -> ThreadedMonitor:
     mon = ThreadedMonitor(
@@ -148,6 +147,15 @@ def good_monitor(
     mon.running.wait(timeout=2.0)
 
     return mon
+
+
+@pytest.fixture(scope="function")
+def good_monitor(
+    save_queue, incomplete_documents, kafka_topic, kafka_bootstrap_ip
+) -> ThreadedMonitor:
+    return _create_good_monitor(
+        save_queue, incomplete_documents, kafka_topic, kafka_bootstrap_ip
+    )
 
 
 #
@@ -426,3 +434,47 @@ def test_seek_start(kafka_producer, kafka_consumer, kafka_topic, run_engine_with
 
     # From descriptor to start
     seek_and_assert_positions(original_offset + 1, "descriptor")
+
+
+def test_seek_start_in_monitor(
+    run_engine_without_md,
+    incomplete_documents,
+    save_queue: queue.Queue,
+    kafka_topic,
+    kafka_bootstrap_ip,
+):
+    det = hw().det
+
+    # NOTE: Add another run before this one just to check it doesn't skip into the previous run.
+    run_engine_without_md(bp.count([det], num=1))
+
+    def custom_plan():
+        yield from bps.open_run({})
+        yield from bps.declare_stream(det, name="primary")
+        for _ in range(5):
+            yield from bps.create()
+            yield from bps.read(det)
+            yield from bps.save()
+
+        monitor = _create_good_monitor(
+            save_queue, incomplete_documents, kafka_topic, kafka_bootstrap_ip
+        )
+        assert monitor.is_alive()
+
+        for _ in range(5):
+            yield from bps.create()
+            yield from bps.read(det)
+            yield from bps.save()
+        yield from bps.close_run("success")
+
+        # Only populated if 'monitor' is working properly, and rewinded to the start document.
+        assert save_queue.get(True, timeout=2.0) is not None
+
+        monitor.close()
+        _wait(
+            lambda: not monitor.running.is_set(),
+            timeout=2.0,
+            timeout_msg="Monitor took too long to close.",
+        )
+
+    run_engine_without_md(custom_plan())

--- a/tests/utils/test_kafka_monitor.py
+++ b/tests/utils/test_kafka_monitor.py
@@ -1,38 +1,13 @@
 import pytest
 
 import queue
-from datetime import datetime, timezone
-
-import msgpack
-import msgpack_numpy as _m
-
-from kafka.producer import KafkaProducer
-from kafka.consumer import KafkaConsumer
-from kafka.structs import TopicPartition
-
-import numpy as np
 
 from ophyd.sim import hw
 from bluesky import RunEngine, plans as bp, plan_stubs as bps, preprocessors as bpp
 
 from sophys.common.utils.kafka.monitor import ThreadedMonitor
 
-from sophys.common.utils.kafka.monitor import seek_start, seek_back_in_time
-
 from . import _wait
-
-
-_m.patch()
-
-
-@pytest.fixture(scope="session")
-def kafka_bootstrap_ip():
-    return "localhost:9092"
-
-
-@pytest.fixture(scope="session")
-def kafka_topic():
-    return "test_bluesky_raw_docs"
 
 
 @pytest.fixture(scope="function")
@@ -85,30 +60,6 @@ def incomplete_documents(_incomplete_documents):
 
 
 @pytest.fixture(scope="function")
-def kafka_producer(kafka_bootstrap_ip):
-    producer = KafkaProducer(
-        bootstrap_servers=[kafka_bootstrap_ip], value_serializer=msgpack.dumps
-    )
-    yield producer
-    producer.flush()
-    producer.close()
-
-
-@pytest.fixture(scope="function")
-def kafka_consumer(kafka_bootstrap_ip, kafka_topic):
-    consumer = KafkaConsumer(
-        kafka_topic,
-        bootstrap_servers=[kafka_bootstrap_ip],
-        value_deserializer=msgpack.unpackb,
-    )
-
-    # Connect the consumer properly to the topic
-    consumer.poll(timeout_ms=100, max_records=1, update_offsets=False)
-
-    return consumer
-
-
-@pytest.fixture(scope="function")
 def base_md(tmp_path_factory):
     return {
         "metadata_save_file_location": str(tmp_path_factory.mktemp("metadata")),
@@ -119,13 +70,6 @@ def base_md(tmp_path_factory):
 @pytest.fixture(scope="function")
 def run_engine_with_md(base_md, kafka_producer, kafka_topic):
     RE = RunEngine(base_md)
-    RE.subscribe(lambda name, doc: kafka_producer.send(kafka_topic, (name, doc)))
-    return RE
-
-
-@pytest.fixture(scope="function")
-def run_engine_without_md(kafka_producer, kafka_topic):
-    RE = RunEngine()
     RE.subscribe(lambda name, doc: kafka_producer.send(kafka_topic, (name, doc)))
     return RE
 
@@ -378,62 +322,6 @@ def test_basic_custom_plan_with_two_nested_runs(
     assert len(docs) == 4, docs.get_raw_data()
 
 
-def test_seek_start(
-    kafka_producer, kafka_consumer: KafkaConsumer, kafka_topic, run_engine_without_md
-):
-    partition_number = list(kafka_consumer.partitions_for_topic(kafka_topic))[0]
-    topic_partition = TopicPartition(kafka_topic, partition_number)
-    original_offset = kafka_consumer.position(topic_partition)
-
-    uid, *_ = run_engine_without_md(bp.count([hw().det], num=10))
-
-    def seek_and_assert_positions(offset: int, seeked_event_name: str):
-        kafka_consumer.seek(topic_partition, offset)
-
-        records = kafka_consumer.poll(
-            timeout_ms=1_000, max_records=1, update_offsets=False
-        )
-        event_name, event_data = records[topic_partition][0].value
-
-        assert event_name == seeked_event_name
-
-        seek_start(
-            kafka_consumer,
-            kafka_topic,
-            partition_number,
-            offset,
-            event_name,
-            event_data,
-        )
-
-        records = kafka_consumer.poll(
-            timeout_ms=1_000, max_records=1, update_offsets=False
-        )
-        event_name, _ = records[topic_partition][0].value
-
-        assert event_name == "start"
-
-    kafka_producer.flush(timeout=1.0)
-    while kafka_consumer.poll(timeout_ms=100) != {}:
-        pass
-
-    new_offset = kafka_consumer.position(topic_partition)
-    # start (1) + descriptor (1) + events (10) + stop (1)
-    assert new_offset - original_offset == 13
-
-    # From stop to start
-    seek_and_assert_positions(new_offset - 1, "stop")
-
-    # From start to start (do nothing)
-    seek_and_assert_positions(original_offset, "start")
-
-    # From event in the middle to start
-    seek_and_assert_positions(original_offset + 5, "event")
-
-    # From descriptor to start
-    seek_and_assert_positions(original_offset + 1, "descriptor")
-
-
 def test_seek_start_in_monitor(
     run_engine_without_md,
     incomplete_documents,
@@ -476,46 +364,3 @@ def test_seek_start_in_monitor(
         )
 
     run_engine_without_md(custom_plan())
-
-
-def test_seek_back_in_time(
-    kafka_producer, kafka_consumer: KafkaConsumer, kafka_topic, run_engine_without_md
-):
-    partition_number = list(kafka_consumer.partitions_for_topic(kafka_topic))[0]
-    topic_partition = TopicPartition(kafka_topic, partition_number)
-
-    kafka_consumer.seek_to_beginning()
-    oldest_offset = kafka_consumer.position(topic_partition)
-
-    kafka_consumer.seek_to_end()
-    newest_offset = kafka_consumer.position(topic_partition)
-
-    if newest_offset - oldest_offset < 5:
-        # Add some new time-spaced data.
-        for _ in range(5):
-            run_engine_without_md(bp.count([hw().det], num=2, delay=1))
-        while kafka_consumer.poll(timeout_ms=100) != {}:
-            pass
-        newest_offset = kafka_consumer.position(topic_partition)
-
-    offsets = [round(x) for x in np.linspace(oldest_offset, newest_offset - 1, num=5)]
-    timestamps = list()
-    for offset in offsets:
-        kafka_consumer.seek(topic_partition, offset)
-
-        record = kafka_consumer.poll(
-            timeout_ms=1_000, max_records=1, update_offsets=False
-        )[topic_partition][0]
-        timestamps.append(record.timestamp // 1000)
-
-    for expected_timestamp in timestamps:
-        time_delta = datetime.now(timezone.utc) - datetime.fromtimestamp(
-            expected_timestamp, tz=timezone.utc
-        )
-        seek_back_in_time(kafka_consumer, time_delta)
-
-        record = kafka_consumer.poll(
-            timeout_ms=1_000, max_records=1, update_offsets=False
-        )[topic_partition][0]
-
-        assert np.isclose(record.timestamp // 1000, expected_timestamp, atol=1)


### PR DESCRIPTION
This PR is kind of a sinkhole where I've put everything I wanted to change in the Kafka monitor. It contains a lot of refactoring to streamline and simplify the code, as well as changes to how we interact with the `KafkaConsumer` API, now that I understand it a bit better.

Furthermore, this patch series contains the changes to `seek_start` (now `seek_start_document`) from #41, as well as a feature imported from `sophys-live-view`, `seek_back_in_time` with the `hour_offset` parameter in the monitor. My intention here is to have a robust and generic implementation for these utilities, so we can share code between `sophys-common`, `sophys-live-view`, and maybe others in the future.

I've spent quite some effort in the automated tests, so that we could trust those implementation changes. I would suggest looking at them when reviewing to maybe get a better understanding of what the code is supposed to be doing!

Supersedes #41