### PR TITLE
Add `AcquireTimeWithReadout` to handle both `acquire_time` and `acquire_period`. 

### DIFF
--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -126,7 +126,7 @@ class DetReadout(Signal):
         super().__init__(name=name, value=value, **kwargs)
 
 
-class AcquireTimePlugin(Device):
+class AcquireTimeWithReadout(Device):
     """Handles the realtionship between Acquire Time and Period and sets both in the correct order."""
 
     det_readout = ADComponent(DetReadout, kind="config")
@@ -194,7 +194,7 @@ class PimegaCam(CamBase_V33):
 
     acquire_time = ADComponent(EpicsSignalWithRBV, "AcquireTime")
     acquire_period = ADComponent(EpicsSignalWithRBV, "AcquirePeriod")
-    acquire_time_with_readout = ADComponent(AcquireTimePlugin, "Acquire")
+    acquire_time_with_readout = ADComponent(AcquireTimeWithReadout, "Acquire")
 
     medipix_mode = ADComponent(EpicsSignalWithRBV, "MedipixMode")
 

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -107,26 +107,10 @@ class PimegaAcquire(Device):
             self.acquire.put(1, **kwargs)
 
 
-class DetReadout(Signal):
-    """
-    Readout signal for `PimegaCam`.
-
-    Parameters
-    ----------
-    value: float
-        Detector's readout value.
-
-
-    """
-
-    def __init__(self, *, name, value=0.01, **kwargs):
-        super().__init__(name=name, value=value, **kwargs)
-
-
 class AcquireTimeWithReadout(Device):
     """Handles the realtionship between Acquire Time and Period and sets both in the correct order."""
 
-    det_readout = ADComponent(DetReadout, kind="config")
+    det_readout = ADComponent(Signal, value=0.01, kind="config")
 
     def set(self, value, **kwargs):
         # Here value corresponds to AcquireTime. The AcquirePeriod will be set automatically.

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -112,22 +112,25 @@ class AcquireTimeWithReadout(Device):
 
     det_readout = ADComponent(Signal, value=0.01, kind="config")
 
-    def set_acquire_time_period(self, value, **kwargs):
+    def set_acquire_time_period(self, value, method, **kwargs):
         # Here value corresponds to AcquireTime. The AcquirePeriod will be set automatically.
         if self.parent.acquire_period.get() <= (value - self.det_readout.get()):
-            self.parent.acquire_period.set(
+            getattr(self.parent.acquire_period, method)(
                 value + self.det_readout.get(), **kwargs
-            ).wait(timeout=15.0)
-            return self.parent.acquire_time.set(value)
+            )
+            return getattr(self.parent.acquire_time, method)(value, **kwargs)
+
         else:
-            self.parent.acquire_time.set(value).wait(timeout=15.0)
-            return self.parent.acquire_period.set(value + self.det_readout.get())
+            getattr(self.parent.acquire_time, method)(value, **kwargs)
+            return getattr(self.parent.acquire_period, method)(
+                value + self.det_readout.get(), **kwargs
+            )
 
     def set(self, value, **kwargs):
-        return self.set_acquire_time_period(value, **kwargs)
+        return self.set_acquire_time_period(value, method="set", **kwargs)
 
     def put(self, value, **kwargs):
-        self.set_acquire_time_period(value, **kwargs)
+        self.set_acquire_time_period(value, method="put", **kwargs)
 
     def read(self, *args, **kwargs):
         res = super().read(*args, **kwargs)

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -112,7 +112,7 @@ class AcquireTimeWithReadout(Device):
 
     det_readout = ADComponent(Signal, value=0.01, kind="config")
 
-    def set(self, value, **kwargs):
+    def set_acquire_time_period(self, value, **kwargs):
         # Here value corresponds to AcquireTime. The AcquirePeriod will be set automatically.
         if self.parent.acquire_period.get() <= (value - self.det_readout.get()):
             self.parent.acquire_period.set(
@@ -123,18 +123,11 @@ class AcquireTimeWithReadout(Device):
             self.parent.acquire_time.set(value).wait(timeout=15.0)
             return self.parent.acquire_period.set(value + self.det_readout.get())
 
-    def put(self, value, **kwargs):
-        if self.parent.acquire_period.get() <= (value - self.det_readout.get()):
-            self.parent.acquire_period.set(
-                value + self.det_readout.get(), **kwargs
-            ).wait(timeout=15.0)
-            self.parent.acquire_time.set(value).wait(timeout=15.0)
+    def set(self, value, **kwargs):
+        return self.set_acquire_time_period(value, **kwargs)
 
-        else:
-            self.parent.acquire_time.set(value).wait(timeout=15.0)
-            self.parent.acquire_period.set(value + self.det_readout.get()).wait(
-                timeout=15.0
-            )
+    def put(self, value, **kwargs):
+        self.set_acquire_time_period(value, **kwargs)
 
     def read(self, *args, **kwargs):
         res = super().read(*args, **kwargs)

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -8,6 +8,7 @@ from ophyd import (
     EpicsSignalWithRBV,
     Device,
     EpicsSignalNoValidation,
+    Signal,
 )
 from ophyd.status import SubscriptionStatus
 from ophyd.flyers import FlyerInterface
@@ -16,6 +17,7 @@ from ophyd.areadetector.detectors import DetectorBase
 from ophyd.areadetector.paths import EpicsPathSignal
 from ophyd.areadetector.trigger_mixins import ADTriggerStatus, SingleTrigger
 from .cam import CamBase_V33
+from bluesky.utils import FailedStatus
 
 from ..utils.status import PremadeStatus
 
@@ -108,6 +110,80 @@ class PimegaAcquire(Device):
             self.acquire.put(1, **kwargs)
 
 
+class DetReadout(Signal):
+    """
+    Readout signal for `PimegaCam`.
+
+    Parameters
+    ----------
+    value: float
+        Detector's readout value.
+
+
+    """
+
+    def __init__(self, *, name, value=0.01, **kwargs):
+        super().__init__(name=name, value=value, **kwargs)
+
+
+class AcquireTimePlugin(Device):
+    """Handles the realtionship between Acquire Time and Period and sets both in the correct order."""
+
+    det_readout = ADComponent(DetReadout, kind="config")
+
+    def set(self, value, **kwargs):
+        # Here value corresponds to AcquireTime. The AcquirePeriod will be set automatically.
+        if self.parent.acquire_period.get() <= (value - self.det_readout.get()):
+            self.parent.acquire_period.set(
+                value + self.det_readout.get(), **kwargs
+            ).wait(timeout=15.0)
+            return self.parent.acquire_time.set(value)
+        else:
+            self.parent.acquire_time.set(value).wait(timeout=15.0)
+            return self.parent.acquire_period.set(value + self.det_readout.get())
+
+    def put(self, value, **kwargs):
+        if self.parent.acquire_period.get() <= (value - self.det_readout.get()):
+            self.parent.acquire_period.set(
+                value + self.det_readout.get(), **kwargs
+            ).wait(timeout=15.0)
+            self.parent.acquire_time.set(value).wait(timeout=15.0)
+
+        else:
+            self.parent.acquire_time.set(value).wait(timeout=15.0)
+            self.parent.acquire_period.set(value + self.det_readout.get()).wait(
+                timeout=15.0
+            )
+
+    def read(self, *args, **kwargs):
+        res = super().read(*args, **kwargs)
+
+        for component in (self.parent.acquire_time, self.parent.acquire_period):
+            res.update(component.read(*args, **kwargs))
+        return res
+
+
+class FilePathPlugin(Device):
+    """Sets the file path for the Pimega detector and checks for the existance of it. It raises a `FailedStatus` if the path does not exists."""
+
+    def set(self, value, **kwargs):
+        value = str(value)
+        self.parent.file_path.set(value).wait(timeout=15.0)
+        if self.parent.file_path_exists.get() != "Yes":
+            raise FailedStatus(
+                f"The file path ({value}) passed to the Pimega detector doesn't exist!"
+            )
+        else:
+            return PremadeStatus(success=True)
+
+    def read(self, *args, **kwargs):
+        res = super().read(*args, **kwargs)
+
+        for component in (self.parent.file_path, self.parent.file_path_exists):
+            res.update(component.read(*args, **kwargs))
+        return res
+
+
 class PimegaCam(CamBase_V33):
 
     magic_start = ADComponent(EpicsSignal, "MagicStart")
@@ -118,6 +194,7 @@ class PimegaCam(CamBase_V33):
 
     acquire_time = ADComponent(EpicsSignalWithRBV, "AcquireTime")
     acquire_period = ADComponent(EpicsSignalWithRBV, "AcquirePeriod")
+    acquire_time_with_readout = ADComponent(AcquireTimePlugin, "Acquire")
 
     medipix_mode = ADComponent(EpicsSignalWithRBV, "MedipixMode")
 
@@ -130,6 +207,7 @@ class PimegaCam(CamBase_V33):
     dac = ADComponent(Digital2AnalogConverter, "DAC_")
 
     file_name = ADComponent(EpicsSignalWithRBV, "FileName", string=True)
+    file_path_with_validation = ADComponent(FilePathPlugin, kind="config")
     file_path = ADComponent(
         EpicsPathSignal, "FilePath", path_semantics="posix", string=True
     )

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -115,11 +115,13 @@ class AcquireTimeWithReadout(Device):
     def set_acquire_time_period(self, value, method, **kwargs):
         # Here value corresponds to AcquireTime. The AcquirePeriod will be set automatically.
         if self.parent.acquire_period.get() <= (value - self.det_readout.get()):
-            self.parent.acquire_period.set(value + self.det_readout.get(), **kwargs)
+            self.parent.acquire_period.set(
+                value + self.det_readout.get(), **kwargs
+            ).wait(**kwargs)
             return getattr(self.parent.acquire_time, method)(value, **kwargs)
 
         else:
-            self.parent.acquire_time.set(value, **kwargs)
+            self.parent.acquire_time.set(value, **kwargs).wait(**kwargs)
             return getattr(self.parent.acquire_period, method)(
                 value + self.det_readout.get(), **kwargs
             )

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -17,9 +17,6 @@ from ophyd.areadetector.detectors import DetectorBase
 from ophyd.areadetector.paths import EpicsPathSignal
 from ophyd.areadetector.trigger_mixins import ADTriggerStatus, SingleTrigger
 from .cam import CamBase_V33
-from bluesky.utils import FailedStatus
-
-from ..utils.status import PremadeStatus
 
 
 class ChipsModulesMode(IntEnum):
@@ -163,27 +160,6 @@ class AcquireTimeWithReadout(Device):
         return res
 
 
-class FilePathPlugin(Device):
-    """Sets the file path for the Pimega detector and checks for the existance of it. It raises a `FailedStatus` if the path does not exists."""
-
-    def set(self, value, **kwargs):
-        value = str(value)
-        self.parent.file_path.set(value).wait(timeout=15.0)
-        if self.parent.file_path_exists.get() != "Yes":
-            raise FailedStatus(
-                f"The file path ({value}) passed to the Pimega detector doesn't exist!"
-            )
-        else:
-            return PremadeStatus(success=True)
-
-    def read(self, *args, **kwargs):
-        res = super().read(*args, **kwargs)
-
-        for component in (self.parent.file_path, self.parent.file_path_exists):
-            res.update(component.read(*args, **kwargs))
-        return res
-
-
 class PimegaCam(CamBase_V33):
 
     magic_start = ADComponent(EpicsSignal, "MagicStart")
@@ -207,7 +183,6 @@ class PimegaCam(CamBase_V33):
     dac = ADComponent(Digital2AnalogConverter, "DAC_")
 
     file_name = ADComponent(EpicsSignalWithRBV, "FileName", string=True)
-    file_path_with_validation = ADComponent(FilePathPlugin, kind="config")
     file_path = ADComponent(
         EpicsPathSignal, "FilePath", path_semantics="posix", string=True
     )

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -170,7 +170,7 @@ class PimegaCam(CamBase_V33):
 
     acquire_time = ADComponent(EpicsSignalWithRBV, "AcquireTime")
     acquire_period = ADComponent(EpicsSignalWithRBV, "AcquirePeriod")
-    acquire_time_with_readout = ADComponent(AcquireTimeWithReadout, "Acquire")
+    acquire_time_with_readout = ADComponent(AcquireTimeWithReadout)
 
     medipix_mode = ADComponent(EpicsSignalWithRBV, "MedipixMode")
 

--- a/src/sophys/common/devices/pimega.py
+++ b/src/sophys/common/devices/pimega.py
@@ -115,13 +115,11 @@ class AcquireTimeWithReadout(Device):
     def set_acquire_time_period(self, value, method, **kwargs):
         # Here value corresponds to AcquireTime. The AcquirePeriod will be set automatically.
         if self.parent.acquire_period.get() <= (value - self.det_readout.get()):
-            getattr(self.parent.acquire_period, method)(
-                value + self.det_readout.get(), **kwargs
-            )
+            self.parent.acquire_period.set(value + self.det_readout.get(), **kwargs)
             return getattr(self.parent.acquire_time, method)(value, **kwargs)
 
         else:
-            getattr(self.parent.acquire_time, method)(value, **kwargs)
+            self.parent.acquire_time.set(value, **kwargs)
             return getattr(self.parent.acquire_period, method)(
                 value + self.det_readout.get(), **kwargs
             )


### PR DESCRIPTION
The new component `AcquireTimeWithReadout` has a `Signal` called `det_readout` that stores the desired detector's readout value. With the defined `set` method, when `AcquireTimeWithReadout` is called within a `bluesky` `mv` plan, it handles the relationship between `acquire_time` and `acquire_period` (`acquire_period = acquire_time + det_readout`) and sets both in the correct order.