### PR TITLE
Add Shutter devices to sophys-common `devices`

### DIFF
--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -36,12 +36,14 @@ class ShutterOpenClose(PVPositionerComparator):
     """
 
     real_setpoint = None
-    setpoint = FormattedComponent(EpicsSignal, "{prefix}{setpoint_suffix}")
+    setpoint = FormattedComponent(
+        EpicsSignal, "{prefix}{setpoint_suffix}", kind="config"
+    )
     readback = FormattedComponent(
         EpicsSignalRO, "{prefix}{readback_suffix}", kind="hinted"
     )
     permission = FormattedComponent(
-        EpicsSignalRO, "{prefix}{permission_suffix}", string=True
+        EpicsSignalRO, "{permission_pv}", string=True, kind="config"
     )
 
     def __init__(
@@ -117,16 +119,16 @@ class ShutterToggle(Device):
     """
 
     setpoint = None
-    phton_status = FormattedComponent(
+    photon_status = FormattedComponent(
         EpicsSignalRO, "{prefix}{ps_suffix}", kind="hinted"
     )
     gamma_status = FormattedComponent(
         EpicsSignalRO, "{prefix}{gs_suffix}", kind="hinted"
     )
-    open = FormattedComponent(EpicsSignal, "{prefix}{open_suffix}")
-    close = FormattedComponent(EpicsSignal, "{prefix}{close_suffix}")
+    open = FormattedComponent(EpicsSignal, "{prefix}{open_suffix}", kind="config")
+    close = FormattedComponent(EpicsSignal, "{prefix}{close_suffix}", kind="config")
     permission = FormattedComponent(
-        EpicsSignalRO, "{prefix}{permission_suffix}", string=True
+        EpicsSignalRO, "{permission_pv}", string=True, kind="config"
     )
 
     def __init__(

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -1,0 +1,110 @@
+from ophyd import EpicsSignal, EpicsSignalRO, FormattedComponent, Device
+from ophyd.pv_positioner import PVPositionerComparator
+from ..utils.status import PremadeStatus
+from ophyd.status import AndStatus, SubscriptionStatus
+
+
+class ShutterOpenClose(PVPositionerComparator):
+    real_setpoint = None
+    setpoint = FormattedComponent(EpicsSignal, "{prefix}{setpoint_suffix}")
+    readback = FormattedComponent(
+        EpicsSignalRO, "{prefix}{readback_suffix}", kind="hinted"
+    )
+    permission = FormattedComponent(
+        EpicsSignalRO, "{prefix}{permission_suffix}", string=True
+    )
+
+    def __init__(
+        self, *args, setpoint_suffix, readback_suffix, permission_suffix, **kwargs
+    ):
+        self.setpoint_suffix = setpoint_suffix
+        self.readback_suffix = readback_suffix
+        self.permission_suffix = permission_suffix
+        super().__init__(*args, **kwargs)
+
+    def set(self, value, *args, **kwargs):
+        if self.permission.connected:
+            if not self.permission.get():
+                raise PremadeStatus(
+                    success=False,
+                    exception=PermissionError(
+                        f"Shutter open permission is denied: {self.permission.pvname} {self.permission.get()}"
+                    ),
+                )
+
+        if value == self.readback.get():
+            self.real_setpoint = 1 if value == 0 else 0
+            return super().set(1, *args, **kwargs)
+        else:
+            return PremadeStatus(success=True)
+
+    def done_comparator(self, readback, setpoint):
+        return self.real_setpoint == readback
+
+
+class ShutterToggle(Device):
+    setpoint = None
+    phton_status = FormattedComponent(
+        EpicsSignalRO, "{prefix}{ps_suffix}", kind="hinted"
+    )
+    gamma_status = FormattedComponent(
+        EpicsSignalRO, "{prefix}{gs_suffix}", kind="hinted"
+    )
+    open = FormattedComponent(EpicsSignal, "{prefix}{open_suffix}")
+    close = FormattedComponent(EpicsSignal, "{prefix}{close_suffix}")
+    permission = FormattedComponent(
+        EpicsSignalRO, "{prefix}{permission_suffix}", string=True
+    )
+
+    def __init__(
+        self,
+        *args,
+        open_suffix,
+        close_suffix,
+        ps_suffix,
+        gs_suffix,
+        permission_suffix,
+        **kwargs,
+    ):
+        self.open_suffix = open_suffix
+        self.close_suffix = close_suffix
+        self.ps_suffix = ps_suffix
+        self.gs_suffix = gs_suffix
+        self.permission_suffix = permission_suffix
+        super().__init__(*args, **kwargs)
+
+    def set(self, value, *args, **kwargs):
+        if self.permission.connected:
+            if not self.permission.get():
+                raise PremadeStatus(
+                    success=False,
+                    exception=PermissionError(
+                        f"Shutter open permission is denied: {self.permission.pvname} {self.permission.get()}"
+                    ),
+                )
+
+        if value == 0:
+            self.close.set(1, *args, **kwargs).wait()
+
+        elif value == 1:
+            self.open.set(1, *args, **kwargs).wait()
+
+        else:
+            raise PremadeStatus(
+                success=False,
+                exception=Exception(f"The value {value} is not a valid option!"),
+            )
+
+        self.setpoint = value
+
+        return AndStatus(
+            SubscriptionStatus(self.phton_status, self.done_comparator, settle_time=3),
+            SubscriptionStatus(self.gamma_status, self.done_comparator, settle_time=3),
+            timeout=15,
+        )
+
+    def done_comparator(self, value, **kwargs):
+        is_closed = (
+            self.phton_status.get() == 1 and self.gamma_status.get() == 1
+        )  # NOTE: if one of the status is equal to zero, the shutter can be partially open
+        return is_closed if self.setpoint == 0 else not is_closed

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -1,7 +1,8 @@
-from ophyd import EpicsSignal, EpicsSignalRO, FormattedComponent, Device
+from ophyd import EpicsSignal, EpicsSignalRO, FormattedComponent, Device, OrderedDict
 from ophyd.pv_positioner import PVPositionerComparator
 from ..utils.status import PremadeStatus
 from ophyd.status import AndStatus, SubscriptionStatus
+from time import time
 
 
 class ShutterOpenClose(PVPositionerComparator):
@@ -79,6 +80,15 @@ class ShutterOpenClose(PVPositionerComparator):
 
     def done_comparator(self, readback, setpoint):
         return self.real_setpoint == readback
+
+    def read_configuration(self, *args, **kwargs):
+        if self.permission.connected:
+            return super().read_configuration(*args, **kwargs)
+        else:
+            return {
+                f"{self.setpoint.name}": self.setpoint.get(*args, **kwargs),
+                "timestamp": time(),
+            }
 
 
 class ShutterToggle(Device):
@@ -188,3 +198,12 @@ class ShutterToggle(Device):
             self.phton_status.get() == 1 and self.gamma_status.get() == 1
         )  # NOTE: if one of the status is equal to zero, the shutter can be partially open
         return is_closed if self.setpoint == 0 else not is_closed
+
+    def read_configuration(self):
+        if self.permission.connected:
+            return super().read_configuration()
+        else:
+            res = OrderedDict()
+            for component in (self.open, self.close):
+                res.update({f"{component.name}": component.get(), "timestamp": time()})
+            return res

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -5,6 +5,36 @@ from ophyd.status import AndStatus, SubscriptionStatus
 
 
 class ShutterOpenClose(PVPositionerComparator):
+    """
+    Abstraction layer for shutters with one actuation PV (OPENCLOSE) and one readback PV (PG_STATUS). There's an optional parameter for a permission PV.
+
+    Parameters
+    ----------
+    prefix: str
+        Prefix for the shutter's PVs.
+
+    setpoint_suffix: str
+        Suffix for the actuation PV, e.g. OPENCLOSE
+
+    readback_suffix: str
+        Suffix for the readback PV, e.g. PG_STATUS
+
+    permission_suffix: str, optional
+        Suffix for a open permssion PV, if it exists.
+
+    NOTE
+    ----
+    This implemantation considers that the value of the `readback` signal is 0 for an open shutter and 1 for a closed shutter.
+    This is not so intuitive, so the `set` method considers that 1 is for opennig and 0 for closing the shutter.
+
+    Usage Example
+    -------------
+    >>> shutter = ShutterOpenClose(prefix="prefix", setpoint_suffix="setpoint_suffix", readback="readback_suffix", name="shutter")
+    >>> from bluesky.plans_stubs import mv
+    >>> RE(mv(shutter, 0)) # for closing
+    >>> RE(mv(shutter, 1)) # for opennig
+    """
+
     real_setpoint = None
     setpoint = FormattedComponent(EpicsSignal, "{prefix}{setpoint_suffix}")
     readback = FormattedComponent(
@@ -32,7 +62,9 @@ class ShutterOpenClose(PVPositionerComparator):
                     ),
                 )
 
-        if value == self.readback.get():
+        if (
+            value == self.readback.get()
+        ):  # Since we're swapping the readback values (o for closing and 1 for opennig), we actuate when value == readback
             self.real_setpoint = 1 if value == 0 else 0
             return super().set(1, *args, **kwargs)
         else:
@@ -43,6 +75,47 @@ class ShutterOpenClose(PVPositionerComparator):
 
 
 class ShutterToggle(Device):
+    """
+    Abstraction layer for shutters with two actuation PV (OPEN and CLOSE) and two readback PV (PS_STATUS and GS_STATUS). There's an optional parameter for a permission PV.
+
+    Parameters
+    ----------
+    prefix: str
+        Prefix for the shutter's PVs.
+
+    open_suffix: str
+        Suffix for the open actuation PV, e.g. OPEN
+
+    close_suffix: str
+        Suffix for the close actuation PV, e.g. CLOSE
+
+    ps_suffix: str
+        Suffix for one readback PVs, e.g. PS_STATUS
+
+    close_suffix: str
+        Suffix for the second readback PV, e.g. GS_STATUS
+
+    permission_suffix: str, optional
+        Suffix for a open permssion PV, if it exists.
+
+    NOTES
+    -----
+    This implemantation considers that the value of the `readback` signal is 0 for an open shutter and 1 for a closed shutter.
+    This is not so intuitive, so the `set` method considers that 1 is for opennig and 0 for closing the shutter.
+
+    The `return` of the `set` method is an `AndStatus` with both `readback` signals.
+
+    There's a `done_comparator` method that returns the state of the shutter, based in the two `readback` PVs. This method is
+    used as the `callback` for both `readback` signals.
+
+    Usage Example
+    -------------
+    >>> shutter = ShutterToggle(prefix="prefix", open_suffix="open_suffix", close_suffix="close_suffix", ps_suffix="ps_suffix", gs_suffix="gs_suffix", name="shutter")
+    >>> from bluesky.plans_stubs import mv
+    >>> RE(mv(shutter, 0)) # for closing
+    >>> RE(mv(shutter, 1)) # for opennig
+    """
+
     setpoint = None
     phton_status = FormattedComponent(
         EpicsSignalRO, "{prefix}{ps_suffix}", kind="hinted"

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -20,7 +20,7 @@ class ShutterOpenClose(PVPositionerComparator):
         Suffix for the readback PV, e.g. PG_STATUS
 
     permission_suffix: str, optional
-        Suffix for a open permssion PV, if it exists.
+        Permssion PV string, if it exists.
 
     NOTE
     ----
@@ -47,11 +47,16 @@ class ShutterOpenClose(PVPositionerComparator):
     )
 
     def __init__(
-        self, *args, setpoint_suffix, readback_suffix, permission_suffix, **kwargs
+        self,
+        *args,
+        setpoint_suffix: str,
+        readback_suffix: str,
+        permission_pv: str = None,
+        **kwargs,
     ):
         self.setpoint_suffix = setpoint_suffix
         self.readback_suffix = readback_suffix
-        self.permission_suffix = permission_suffix
+        self.permission_pv = permission_pv
         super().__init__(*args, **kwargs)
 
     def set(self, value, *args, **kwargs):
@@ -97,8 +102,8 @@ class ShutterToggle(Device):
     close_suffix: str
         Suffix for the second readback PV, e.g. GS_STATUS
 
-    permission_suffix: str, optional
-        Suffix for a open permssion PV, if it exists.
+    permission_pv: str, optional
+        Permssion PV string, if it exists.
 
     NOTES
     -----
@@ -134,18 +139,18 @@ class ShutterToggle(Device):
     def __init__(
         self,
         *args,
-        open_suffix,
-        close_suffix,
-        ps_suffix,
-        gs_suffix,
-        permission_suffix,
+        open_suffix: str,
+        close_suffix: str,
+        ps_suffix: str,
+        gs_suffix: str,
+        permission_pv: str = None,
         **kwargs,
     ):
         self.open_suffix = open_suffix
         self.close_suffix = close_suffix
         self.ps_suffix = ps_suffix
         self.gs_suffix = gs_suffix
-        self.permission_suffix = permission_suffix
+        self.permission_pv = permission_pv
         super().__init__(*args, **kwargs)
 
     def set(self, value, *args, **kwargs):

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -21,7 +21,7 @@ class ShutterToggle(PVPositionerComparator):
         Suffix for the readback PV, e.g. PG_STATUS
 
     permission_suffix: str, optional
-        Permssion PV string, if it exists.
+        Permission PV string, if it exists.
 
     NOTE
     ----
@@ -42,9 +42,6 @@ class ShutterToggle(PVPositionerComparator):
     readback = FormattedComponent(
         EpicsSignalRO, "{prefix}{readback_suffix}", kind="hinted"
     )
-    permission = FormattedComponent(
-        EpicsSignalRO, "{permission_pv}", string=True, kind="omitted"
-    )
 
     def __init__(
         self,
@@ -58,6 +55,11 @@ class ShutterToggle(PVPositionerComparator):
         self.readback_suffix = readback_suffix
         self.permission_pv = permission_pv
         super().__init__(*args, **kwargs)
+        if self.permission_pv is not None:
+            self.permission = EpicsSignalRO(f"{self.permission_pv}", name="permission")
+            self.permission_flag = True
+        else:
+            self.permission_flag = False
 
     def set(self, value, *args, **kwargs):
         if self.permission.connected:
@@ -71,7 +73,7 @@ class ShutterToggle(PVPositionerComparator):
 
         if (
             value == self.readback.get()
-        ):  # Since we're swapping the readback values (o for closing and 1 for opening), we actuate when value == readback
+        ):  # Since we're swapping the readback values (0 for closing and 1 for opening), we actuate when value == readback
             self.real_setpoint = 1 if value == 0 else 0
             return super().set(1, *args, **kwargs)
         else:
@@ -101,7 +103,7 @@ class ShutterOpenClose(Device):
         Suffix for the second readback PV, e.g. GS_STATUS
 
     permission_pv: str, optional
-        Permssion PV string, if it exists.
+        Permission PV string, if it exists.
 
     NOTES
     -----
@@ -133,9 +135,6 @@ class ShutterOpenClose(Device):
     close = FormattedComponent(
         EpicsSignal, "{prefix}{shutter_suffix}CLOSE", kind="config"
     )
-    permission = FormattedComponent(
-        EpicsSignalRO, "{permission_pv}", string=True, kind="omitted"
-    )
 
     def __init__(
         self,
@@ -151,6 +150,11 @@ class ShutterOpenClose(Device):
         self.gs_suffix = gs_suffix
         self.permission_pv = permission_pv
         super().__init__(*args, **kwargs)
+        if self.permission_pv is not None:
+            self.permission = EpicsSignalRO(f"{self.permission_pv}", name="permission")
+            self.permission_flag = True
+        else:
+            self.permission_flag = False
 
     def set(self, value, *args, **kwargs):
         if self.permission.connected:

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -108,7 +108,7 @@ class ShutterOpenClose(Device):
     ps_suffix: str
         Suffix for one readback PVs, e.g. PS_STATUS
 
-    close_suffix: str
+    gs_suffix: str
         Suffix for the second readback PV, e.g. GS_STATUS
 
     permission_pv: str, optional
@@ -186,14 +186,14 @@ class ShutterOpenClose(Device):
         self.setpoint = value
 
         return AndStatus(
-            SubscriptionStatus(self.phton_status, self.done_comparator, settle_time=3),
+            SubscriptionStatus(self.photon_status, self.done_comparator, settle_time=3),
             SubscriptionStatus(self.gamma_status, self.done_comparator, settle_time=3),
             timeout=15,
         )
 
     def done_comparator(self, value, **kwargs):
         is_closed = (
-            self.phton_status.get() == 1 and self.gamma_status.get() == 1
+            self.photon_status.get() == 1 and self.gamma_status.get() == 1
         )  # NOTE: if one of the status is equal to zero, the shutter can be partially open
         return is_closed if self.setpoint == 0 else not is_closed
 

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -110,7 +110,7 @@ class ShutterOpenClose(Device):
     NOTES
     -----
     This implemantation considers that the value of the `readback` signal is 0 for an open shutter and 1 for a closed shutter.
-    This is not so intuitive, so the `set` method considers that 1 is for openig and 0 for closing the shutter.
+    This is not so intuitive, so the `set` method considers that 1 is for opening and 0 for closing the shutter.
 
     The `return` of the `set` method is an `AndStatus` with both `readback` signals.
 

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -1,8 +1,7 @@
-from ophyd import EpicsSignal, EpicsSignalRO, FormattedComponent, Device, OrderedDict
+from ophyd import EpicsSignal, EpicsSignalRO, FormattedComponent, Device
 from ophyd.pv_positioner import PVPositionerComparator
 from ..utils.status import PremadeStatus
 from ophyd.status import AndStatus, SubscriptionStatus
-from time import time
 
 
 class ShutterToggle(PVPositionerComparator):
@@ -43,7 +42,7 @@ class ShutterToggle(PVPositionerComparator):
         EpicsSignalRO, "{prefix}{readback_suffix}", kind="hinted"
     )
     permission = FormattedComponent(
-        EpicsSignalRO, "{permission_pv}", string=True, kind="config"
+        EpicsSignalRO, "{permission_pv}", string=True, kind="omitted"
     )
 
     def __init__(
@@ -79,15 +78,6 @@ class ShutterToggle(PVPositionerComparator):
 
     def done_comparator(self, readback, setpoint):
         return self.real_setpoint == readback
-
-    def read_configuration(self, *args, **kwargs):
-        if self.permission.connected:
-            return super().read_configuration(*args, **kwargs)
-        else:
-            return {
-                f"{self.setpoint.name}": self.setpoint.get(*args, **kwargs),
-                "timestamp": time(),
-            }
 
 
 class ShutterOpenClose(Device):
@@ -141,7 +131,7 @@ class ShutterOpenClose(Device):
     open = FormattedComponent(EpicsSignal, "{prefix}{open_suffix}", kind="config")
     close = FormattedComponent(EpicsSignal, "{prefix}{close_suffix}", kind="config")
     permission = FormattedComponent(
-        EpicsSignalRO, "{permission_pv}", string=True, kind="config"
+        EpicsSignalRO, "{permission_pv}", string=True, kind="omitted"
     )
 
     def __init__(
@@ -196,12 +186,3 @@ class ShutterOpenClose(Device):
             self.photon_status.get() == 1 and self.gamma_status.get() == 1
         )  # NOTE: if one of the status is equal to zero, the shutter can be partially open
         return is_closed if self.setpoint == 0 else not is_closed
-
-    def read_configuration(self):
-        if self.permission.connected:
-            return super().read_configuration()
-        else:
-            res = OrderedDict()
-            for component in (self.open, self.close):
-                res.update({f"{component.name}": component.get(), "timestamp": time()})
-            return res

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -5,7 +5,7 @@ from ophyd.status import AndStatus, SubscriptionStatus
 from time import time
 
 
-class ShutterOpenClose(PVPositionerComparator):
+class ShutterToggle(PVPositionerComparator):
     """
     Abstraction layer for shutters with one actuation PV (OPENCLOSE) and one readback PV (PG_STATUS). There's an optional parameter for a permission PV.
 
@@ -91,7 +91,7 @@ class ShutterOpenClose(PVPositionerComparator):
             }
 
 
-class ShutterToggle(Device):
+class ShutterOpenClose(Device):
     """
     Abstraction layer for shutters with two actuation PV (OPEN and CLOSE) and two readback PV (PS_STATUS and GS_STATUS). There's an optional parameter for a permission PV.
 

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -31,9 +31,8 @@ class ShutterToggle(PVPositionerComparator):
     Usage Example
     -------------
     >>> shutter = ShutterOpenClose(prefix="prefix", setpoint_suffix="setpoint_suffix", readback="readback_suffix", name="shutter")
-    >>> from bluesky.plans_stubs import mv
-    >>> RE(mv(shutter, 0)) # for closing
-    >>> RE(mv(shutter, 1)) # for opennig
+    >>> shutter.set(0).wait() # for closing
+    >>> shutter.set(1).wait() # for opening
     """
 
     real_setpoint = None
@@ -128,9 +127,8 @@ class ShutterOpenClose(Device):
     Usage Example
     -------------
     >>> shutter = ShutterToggle(prefix="prefix", open_suffix="open_suffix", close_suffix="close_suffix", ps_suffix="ps_suffix", gs_suffix="gs_suffix", name="shutter")
-    >>> from bluesky.plans_stubs import mv
-    >>> RE(mv(shutter, 0)) # for closing
-    >>> RE(mv(shutter, 1)) # for opennig
+    >>> shutter.set(0).wait() # for closing
+    >>> shutter.set(1).wait() # for opening
     """
 
     setpoint = None

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -171,17 +171,14 @@ class ShutterOpenClose(Device):
             except TimeoutError:
                 raise
 
-        if value == 0:
+        if value == 0 and not self._is_closed():
             self.close.set(1, *args, **kwargs).wait()
 
-        elif value == 1:
+        elif value == 1 and self._is_closed():
             self.open.set(1, *args, **kwargs).wait()
 
         else:
-            raise PremadeStatus(
-                success=False,
-                exception=Exception(f"The value {value} is not a valid option!"),
-            )
+            return PremadeStatus(success=True)
 
         self.setpoint = value
 
@@ -191,8 +188,12 @@ class ShutterOpenClose(Device):
             timeout=15,
         )
 
-    def done_comparator(self, value, **kwargs):
-        is_closed = (
-            self.photon_status.get() == 1 and self.gamma_status.get() == 1
+    def _is_closed(self):
+        """Check wheter the shutter is open or closed given the photon and gamma status PVs."""
+        return (self.photon_status.get() == 1) and (
+            self.gamma_status.get() == 1
         )  # NOTE: if one of the status is equal to zero, the shutter can be partially open
+
+    def done_comparator(self, value, **kwargs):
+        is_closed = self._is_closed()
         return is_closed if self.setpoint == 0 else not is_closed

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -53,26 +53,26 @@ class ShutterToggle(PVPositionerComparator):
     ):
         self.setpoint_suffix = setpoint_suffix
         self.readback_suffix = readback_suffix
-        self.permission_pv = permission_pv
+        self._permission_pv_name = permission_pv
         super().__init__(*args, **kwargs)
-        if self.permission_pv is not None:
-            self.permission = EpicsSignalRO(f"{self.permission_pv}", name="permission")
-            self.permission_flag = True
-        else:
-            self.permission_flag = False
+        if self._permission_pv_name is not None:
+            self.permission_signal = EpicsSignalRO(
+                f"{self._permission_pv_name}", name="permission"
+            )
 
     def set(self, value, *args, **kwargs):
-        if self.permission_flag:
-            try:
-                if not self.permission.get(connection_timeout=2, **kwargs):
-                    raise PremadeStatus(
-                        success=False,
-                        exception=PermissionError(
-                            f"Shutter open permission is denied: {self.permission.pvname} {self.permission.get()}"
-                        ),
-                    )
-            except TimeoutError:
-                raise
+        if hasattr(self, "permission_signal"):
+            permission_status = self.permission_signal.get(
+                connection_timeout=2, **kwargs
+            )
+            if not permission_status:
+                raise PremadeStatus(
+                    success=False,
+                    exception=PermissionError(
+                        f"Shutter open permission is denied: {self.permission_signal.pvname} {permission_status}."
+                    ),
+                )
+
         if (
             value == self.readback.get()
         ):  # Since we're swapping the readback values (0 for closing and 1 for opening), we actuate when value == readback
@@ -150,26 +150,25 @@ class ShutterOpenClose(Device):
         self.shutter_suffix = shutter_suffix
         self.ps_suffix = ps_suffix
         self.gs_suffix = gs_suffix
-        self.permission_pv = permission_pv
+        self._permission_pv_name = permission_pv
         super().__init__(*args, **kwargs)
-        if self.permission_pv is not None:
-            self.permission = EpicsSignalRO(f"{self.permission_pv}", name="permission")
-            self.permission_flag = True
-        else:
-            self.permission_flag = False
+        if self._permission_pv_name is not None:
+            self.permission_signal = EpicsSignalRO(
+                f"{self._permission_pv_name}", name="permission"
+            )
 
     def set(self, value, *args, **kwargs):
-        if self.permission_flag:
-            try:
-                if not self.permission.get(connection_timeout=2, **kwargs):
-                    raise PremadeStatus(
-                        success=False,
-                        exception=PermissionError(
-                            f"Shutter open permission is denied: {self.permission.pvname} {self.permission.get()}"
-                        ),
-                    )
-            except TimeoutError:
-                raise
+        if hasattr(self, "permission_signal"):
+            permission_status = self.permission_signal.get(
+                connection_timeout=2, **kwargs
+            )
+            if not permission_status:
+                raise PremadeStatus(
+                    success=False,
+                    exception=PermissionError(
+                        f"Shutter open permission is denied: {self.permission_signal.pvname} {permission_status}"
+                    ),
+                )
 
         if value == 0 and not self._is_closed():
             self.close.set(1, *args, **kwargs).wait()

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -14,7 +14,8 @@ class ShutterToggle(PVPositionerComparator):
         Prefix for the shutter's PVs.
 
     setpoint_suffix: str
-        Suffix for the actuation PV, e.g. OPENCLOSE
+        Suffix for the actuation PV. NOTE: This should be place/location of the shutter, e.g. OEA/FOE.
+        The PV will be formatted as "{prefix}{setpoint_suffix}OPENCLOSE".
 
     readback_suffix: str
         Suffix for the readback PV, e.g. PG_STATUS
@@ -36,7 +37,7 @@ class ShutterToggle(PVPositionerComparator):
 
     real_setpoint = None
     setpoint = FormattedComponent(
-        EpicsSignal, "{prefix}{setpoint_suffix}", kind="config"
+        EpicsSignal, "{prefix}{setpoint_suffix}OPENCLOSE", kind="config"
     )
     readback = FormattedComponent(
         EpicsSignalRO, "{prefix}{readback_suffix}", kind="hinted"
@@ -89,11 +90,9 @@ class ShutterOpenClose(Device):
     prefix: str
         Prefix for the shutter's PVs.
 
-    open_suffix: str
-        Suffix for the open actuation PV, e.g. OPEN
-
-    close_suffix: str
-        Suffix for the close actuation PV, e.g. CLOSE
+    shutter_suffix: str
+        Suffix for the OPEN and CLOSE PVs. NOTE: This should be place/location of the shutter, e.g. OEA/FOE.
+        The PVs will be formatted as "{prefix}{shutter_suffix}OPEN" and "{prefix}{shutter_suffix}CLOSE".
 
     ps_suffix: str
         Suffix for one readback PVs, e.g. PS_STATUS
@@ -128,8 +127,12 @@ class ShutterOpenClose(Device):
     gamma_status = FormattedComponent(
         EpicsSignalRO, "{prefix}{gs_suffix}", kind="hinted"
     )
-    open = FormattedComponent(EpicsSignal, "{prefix}{open_suffix}", kind="config")
-    close = FormattedComponent(EpicsSignal, "{prefix}{close_suffix}", kind="config")
+    open = FormattedComponent(
+        EpicsSignal, "{prefix}{shutter_suffix}OPEN", kind="config"
+    )
+    close = FormattedComponent(
+        EpicsSignal, "{prefix}{shutter_suffix}CLOSE", kind="config"
+    )
     permission = FormattedComponent(
         EpicsSignalRO, "{permission_pv}", string=True, kind="omitted"
     )
@@ -137,15 +140,13 @@ class ShutterOpenClose(Device):
     def __init__(
         self,
         *args,
-        open_suffix: str,
-        close_suffix: str,
+        shutter_suffix: str,
         ps_suffix: str,
         gs_suffix: str,
         permission_pv: str = None,
         **kwargs,
     ):
-        self.open_suffix = open_suffix
-        self.close_suffix = close_suffix
+        self.shutter_suffix = shutter_suffix
         self.ps_suffix = ps_suffix
         self.gs_suffix = gs_suffix
         self.permission_pv = permission_pv

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -62,15 +62,17 @@ class ShutterToggle(PVPositionerComparator):
             self.permission_flag = False
 
     def set(self, value, *args, **kwargs):
-        if self.permission.connected:
-            if not self.permission.get():
-                raise PremadeStatus(
-                    success=False,
-                    exception=PermissionError(
-                        f"Shutter open permission is denied: {self.permission.pvname} {self.permission.get()}"
-                    ),
-                )
-
+        if self.permission_flag:
+            try:
+                if not self.permission.get(connection_timeout=2, **kwargs):
+                    raise PremadeStatus(
+                        success=False,
+                        exception=PermissionError(
+                            f"Shutter open permission is denied: {self.permission.pvname} {self.permission.get()}"
+                        ),
+                    )
+            except TimeoutError:
+                raise
         if (
             value == self.readback.get()
         ):  # Since we're swapping the readback values (0 for closing and 1 for opening), we actuate when value == readback
@@ -157,14 +159,17 @@ class ShutterOpenClose(Device):
             self.permission_flag = False
 
     def set(self, value, *args, **kwargs):
-        if self.permission.connected:
-            if not self.permission.get():
-                raise PremadeStatus(
-                    success=False,
-                    exception=PermissionError(
-                        f"Shutter open permission is denied: {self.permission.pvname} {self.permission.get()}"
-                    ),
-                )
+        if self.permission_flag:
+            try:
+                if not self.permission.get(connection_timeout=2, **kwargs):
+                    raise PremadeStatus(
+                        success=False,
+                        exception=PermissionError(
+                            f"Shutter open permission is denied: {self.permission.pvname} {self.permission.get()}"
+                        ),
+                    )
+            except TimeoutError:
+                raise
 
         if value == 0:
             self.close.set(1, *args, **kwargs).wait()

--- a/src/sophys/common/devices/shutters.py
+++ b/src/sophys/common/devices/shutters.py
@@ -26,7 +26,7 @@ class ShutterToggle(PVPositionerComparator):
     NOTE
     ----
     This implemantation considers that the value of the `readback` signal is 0 for an open shutter and 1 for a closed shutter.
-    This is not so intuitive, so the `set` method considers that 1 is for opennig and 0 for closing the shutter.
+    This is not so intuitive, so the `set` method considers that 1 is for opening and 0 for closing the shutter.
 
     Usage Example
     -------------
@@ -71,7 +71,7 @@ class ShutterToggle(PVPositionerComparator):
 
         if (
             value == self.readback.get()
-        ):  # Since we're swapping the readback values (o for closing and 1 for opennig), we actuate when value == readback
+        ):  # Since we're swapping the readback values (o for closing and 1 for opening), we actuate when value == readback
             self.real_setpoint = 1 if value == 0 else 0
             return super().set(1, *args, **kwargs)
         else:
@@ -106,7 +106,7 @@ class ShutterOpenClose(Device):
     NOTES
     -----
     This implemantation considers that the value of the `readback` signal is 0 for an open shutter and 1 for a closed shutter.
-    This is not so intuitive, so the `set` method considers that 1 is for opennig and 0 for closing the shutter.
+    This is not so intuitive, so the `set` method considers that 1 is for openig and 0 for closing the shutter.
 
     The `return` of the `set` method is an `AndStatus` with both `readback` signals.
 


### PR DESCRIPTION
Two types of shutters were developed, `ShutterOpenClose` (with one actuation and one readback PV) and `ShutterToggle` (with two actuation and readback PVs).
The devices consider that the readback value of 0 represent an open shutter whereas a value of 1 represent a closed shutter. In the `set` method logic, this values are swapped, e.g. a `set` call with 0 closes the shutter and a call with 1 opens it. 
