### PR TITLE
Make CNEN signal of the `config` kind in virtual motors

### DIFF
--- a/src/sophys/common/devices/motor.py
+++ b/src/sophys/common/devices/motor.py
@@ -73,7 +73,7 @@ def _create_virtual_controllable_motor(components):
     formattedComponents = {}
     for key, motorPv in components.items():
         formattedComponents["cnen_" + key] = FormattedComponent(
-            EpicsSignal, suffix=motorPv + ".CNEN"
+            EpicsSignal, suffix=motorPv + ".CNEN", kind="config"
         )
 
     devClass = create_device_from_components(


### PR DESCRIPTION
This prevents the signal from showing up in clients using the kind information to display data. For instance, it prevents the CNEN signals from being considered proper data signals in `sophys-live-view`.