### PR TITLE
Add Mass Flow Controller (MFC) device.

### DIFF
--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -1,6 +1,6 @@
 from ophyd import Device, Component, EpicsSignalWithRBV, EpicsSignalRO, EpicsSignal
 from enum import StrEnum
-from ophyd.pv_positioner import PVPositionerDone
+from ophyd.pv_positioner import PVPositionerIsClose
 
 
 class MixFractionType(StrEnum):
@@ -33,10 +33,9 @@ class MFCMixFluid(Device):
     fraction = Component(EpicsSignalWithRBV, "Fraction", kind="config")
 
 
-class MFC(PVPositionerDone):
+class MFC(PVPositionerIsClose):
     """
-    Bronkhorst's Prestige series Mass Flow Controller Ophyd device, with the `PVPositioner` interface.
-    This class is initialized with its flow limits set to (0, 32000), following the manufacturer's recommendation.
+    Bronkhorst's Prestige series Mass Flow Controller Ophyd device, with the `PVPositionerIsClose` interface.
     """
 
     raw_setpoint = Component(EpicsSignalWithRBV, "Setpoint", kind="config")
@@ -46,6 +45,7 @@ class MFC(PVPositionerDone):
 
     readback = Component(EpicsSignalRO, "FloatMeasure_RBV", kind="hinted")
     setpoint = Component(EpicsSignalWithRBV, "FloatSetpoint", kind="config")
+    actuate = Component(EpicsSignalWithRBV, "EnableSetpoint", kind="config")
     capacity = Component(EpicsSignalWithRBV, "Capacity", kind="config")
     capacity_unit = Component(
         EpicsSignalWithRBV, "CapacityUnit", string=True, kind="config"

--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -64,5 +64,6 @@ class MFC(PVPositionerIsClose):
 
     init_reset = Component(EpicsSignalWithRBV, "InitReset", string=True, kind="config")
 
-    def __init__(self, *args, limits=(0, 32000), **kwargs):
-        super().__init__(*args, limits=limits, **kwargs)
+    @property
+    def egu(self):
+        return self.capacity_unit.get(timeout=5, connection_timeout=5)

--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -43,3 +43,8 @@ class MFC(PVPositionerIsClose):
     @property
     def egu(self):
         return self.capacity_unit.get(timeout=5, connection_timeout=5)
+
+    def __init__(self, prefix, *, name, atol=1e-2, rtol=None, timeout=10, **kwargs):
+        super().__init__(
+            prefix, name=name, atol=atol, rtol=rtol, timeout=timeout, **kwargs
+        )

--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -1,7 +1,7 @@
 from ophyd import Device, Component, EpicsSignalWithRBV, EpicsSignalRO, EpicsSignal
 from bluesky.utils import FailedStatus
-from sophys.common.utils.status import PremadeStatus
 from enum import StrEnum
+from ophyd.pv_positioner import PVPositionerDone
 
 
 class MixFractionType(StrEnum):
@@ -33,23 +33,15 @@ class MFCMixFluid(Device):
     fraction = Component(EpicsSignalWithRBV, "Fraction", kind="config")
 
 
-class MFCFlow(EpicsSignalWithRBV):
-    def set(self, value, *args, **kwargs):
-        if 0 <= value <= 32000:  # check for the allowed dimensionless flow range
-            return super().set(value, *args, **kwargs)
-        else:
-            return PremadeStatus(success=False, exception=MFCFlowValueError(value))
-
-
-class MFC(Device):
-    setpoint = Component(MFCFlow, "Setpoint", kind="config")
+class MFC(PVPositionerDone):
+    setpoint = Component(EpicsSignalWithRBV, "Setpoint", kind="config")
     readback = Component(
         EpicsSignalRO, "Measure_RBV", kind="hinted"
     )  # Dimensionless metered value of flow
 
     fmeasure = Component(EpicsSignalRO, "FloatMeasure_RBV", kind="hinted")
     fsetpoint = Component(EpicsSignalWithRBV, "FloatSetpoint", kind="config")
-    capacity = Component(EpicsSignalWithRBV, "Capacity", kind="config")  #
+    capacity = Component(EpicsSignalWithRBV, "Capacity", kind="config")
     capacity_unit = Component(
         EpicsSignalWithRBV, "CapacityUnit", string=True, kind="config"
     )
@@ -66,3 +58,6 @@ class MFC(Device):
     temperature = Component(EpicsSignalRO, "Temperature_RBV", kind="config")
 
     init_reset = Component(EpicsSignalWithRBV, "InitReset", string=True, kind="config")
+
+    def __init__(self, *args, limits=(0, 32000), **kwargs):
+        super().__init__(*args, limits=limits, **kwargs)

--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -1,4 +1,4 @@
-from ophyd import Device, Component, EpicsSignalWithRBV, EpicsSignalRO, EpicsSignal
+from ophyd import Device, Component, EpicsSignalWithRBV, EpicsSignalRO
 from enum import StrEnum
 from ophyd.pv_positioner import PVPositionerIsClose
 
@@ -23,14 +23,11 @@ class MFCMixFluid(Device):
     Device that aggragates the PVs with suffix `Mix` from the MFC's IOC. It's meant to be used as a `Component` for the `MFC` device.
     """
 
-    fluid_name_list = Component(
-        EpicsSignal, "FluidNameList", string=True, kind="config"
-    )
-    fluid_name = Component(EpicsSignalRO, "FluidName_RBV", string=True, kind="config")
+    fluid_name = Component(EpicsSignalRO, "FluidNameList", string=True, kind="config")
     fraction_type = Component(
-        EpicsSignalWithRBV, "FractionType", string=True, kind="config"
+        EpicsSignalRO, "FractionType_RBV", string=True, kind="config"
     )
-    fraction = Component(EpicsSignalWithRBV, "Fraction", kind="config")
+    fraction = Component(EpicsSignalRO, "Fraction_RBV", kind="config")
 
 
 class MFC(PVPositionerIsClose):
@@ -46,23 +43,18 @@ class MFC(PVPositionerIsClose):
     readback = Component(EpicsSignalRO, "FloatMeasure_RBV", kind="hinted")
     setpoint = Component(EpicsSignalWithRBV, "FloatSetpoint", kind="config")
     actuate = Component(EpicsSignalWithRBV, "EnableSetpoint", kind="config")
-    capacity = Component(EpicsSignalWithRBV, "Capacity", kind="config")
+    capacity = Component(EpicsSignalRO, "Capacity_RBV", kind="config")
     capacity_unit = Component(
-        EpicsSignalWithRBV, "CapacityUnit", string=True, kind="config"
+        EpicsSignalRO, "CapacityUnit_RBV", string=True, kind="config"
     )
 
-    fluid_name = Component(EpicsSignalRO, "FluidName_RBV", string=True, kind="config")
-    fluid_name_list = Component(
-        EpicsSignal, "FluidNameList", string=True, kind="config"
-    )
+    fluid_name = Component(EpicsSignalRO, "FluidNameList", string=True, kind="config")
     mix = Component(MFCMixFluid, "Mix", kind="config")
 
-    inlet_pressure = Component(EpicsSignalWithRBV, "InletPressure", kind="config")
-    outlet_pressure = Component(EpicsSignalWithRBV, "OutletPressure", kind="config")
+    inlet_pressure = Component(EpicsSignalRO, "InletPressure_RBV", kind="config")
+    outlet_pressure = Component(EpicsSignalRO, "OutletPressure_RBV", kind="config")
 
     temperature = Component(EpicsSignalRO, "Temperature_RBV", kind="config")
-
-    init_reset = Component(EpicsSignalWithRBV, "InitReset", string=True, kind="config")
 
     @property
     def egu(self):

--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -1,0 +1,68 @@
+from ophyd import Device, Component, EpicsSignalWithRBV, EpicsSignalRO, EpicsSignal
+from bluesky.utils import FailedStatus
+from sophys.common.utils.status import PremadeStatus
+from enum import StrEnum
+
+
+class MixFractionType(StrEnum):
+    VOLUME_FRACTION = "Volume fraction"
+    MASS_FRACTION = "Mass fraction"
+    MOLE_FRACTION = "Mole fraction"
+
+
+class InitResetType(StrEnum):
+    UNLOCKED = "unlocked"
+    LOCKED = "locked"
+
+
+class MFCFlowValueError(FailedStatus):
+    def __init__(self, value):
+        super().__init__(
+            f"The flow value {value} is out of range. The allowed range is between 0 and 32000"
+        )
+
+
+class MFCMixFluid(Device):
+    fluid_name_list = Component(
+        EpicsSignal, "FluidNameList", string=True, kind="config"
+    )
+    fluid_name = Component(EpicsSignalRO, "FluidName_RBV", string=True, kind="config")
+    fraction_type = Component(
+        EpicsSignalWithRBV, "FractionType", string=True, kind="config"
+    )
+    fraction = Component(EpicsSignalWithRBV, "Fraction", kind="config")
+
+
+class MFCFlow(EpicsSignalWithRBV):
+    def set(self, value, *args, **kwargs):
+        if 0 <= value <= 32000:  # check for the allowed dimensionless flow range
+            return super().set(value, *args, **kwargs)
+        else:
+            return PremadeStatus(success=False, exception=MFCFlowValueError(value))
+
+
+class MFC(Device):
+    setpoint = Component(MFCFlow, "Setpoint", kind="config")
+    readback = Component(
+        EpicsSignalRO, "Measure_RBV", kind="hinted"
+    )  # Dimensionless metered value of flow
+
+    fmeasure = Component(EpicsSignalRO, "FloatMeasure_RBV", kind="hinted")
+    fsetpoint = Component(EpicsSignalWithRBV, "FloatSetpoint", kind="config")
+    capacity = Component(EpicsSignalWithRBV, "Capacity", kind="config")  #
+    capacity_unit = Component(
+        EpicsSignalWithRBV, "CapacityUnit", string=True, kind="config"
+    )
+
+    fluid_name = Component(EpicsSignalRO, "FluidName_RBV", string=True, kind="config")
+    fluid_name_list = Component(
+        EpicsSignal, "FluidNameList", string=True, kind="config"
+    )
+    mix = Component(MFCMixFluid, "Mix", kind="config")
+
+    inlet_pressure = Component(EpicsSignalWithRBV, "InletPressure", kind="config")
+    outlet_pressure = Component(EpicsSignalWithRBV, "OutletPressure", kind="config")
+
+    temperature = Component(EpicsSignalRO, "Temperature_RBV", kind="config")
+
+    init_reset = Component(EpicsSignalWithRBV, "InitReset", string=True, kind="config")

--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -1,4 +1,9 @@
-from ophyd import Device, Component, EpicsSignalWithRBV, EpicsSignalRO
+from ophyd import (
+    Device,
+    Component,
+    EpicsSignalWithRBV,
+    EpicsSignalRO,
+)  # numpydoc ignore=GL08
 from ophyd.pv_positioner import PVPositionerIsClose
 
 
@@ -16,7 +21,31 @@ class MFCMixFluid(Device):
 
 class MFC(PVPositionerIsClose):
     """
-    Bronkhorst's Prestige series Mass Flow Controller Ophyd device, with the `PVPositionerIsClose` interface.
+    Bronkhorst's Prestige series Mass Flow Controller Ophyd device.
+
+    This device has the `PVPositionerIsClose` interface. The `atol` and `timeout` properties
+    have the defaults `1e-2` and `10` respectively. These can be changed for each equipment
+    or use case. The `egu` is overwritten to show the equipment's capacity unit.
+
+    Parameters
+    ----------
+    prefix : str
+        The device prefix used for all sub-positioners. This is optional as it
+        may be desirable to specify full PV names for PVPositioners.
+    name : str
+        The device name.
+    atol : float, default: 1e-2
+        A measure of absolute tolerance.
+    rtol : float, optional
+        A measure of relative tolerance.
+    timeout : float, default: 10
+        The default timeout to use for motion requests, in seconds.
+    **kwargs
+        Extra keyword arguments passed to `PVPositionerIsClose`.
+
+    See Also
+    --------
+    ophyd.pv_positioner.PVPositionerIsClose: Base class for `PVPositioner` that updates done status based on np.isclose.
     """
 
     raw_setpoint = Component(EpicsSignalWithRBV, "Setpoint", kind="config")
@@ -41,10 +70,12 @@ class MFC(PVPositionerIsClose):
     temperature = Component(EpicsSignalRO, "Temperature_RBV", kind="config")
 
     @property
-    def egu(self):
+    def egu(self):  # numpydoc ignore=GL08
         return self.capacity_unit.get(timeout=5, connection_timeout=5)
 
-    def __init__(self, prefix, *, name, atol=1e-2, rtol=None, timeout=10, **kwargs):
+    def __init__(
+        self, prefix, *, name, atol=1e-2, rtol=None, timeout=10, **kwargs
+    ):  # numpydoc ignore=GL08
         super().__init__(
             prefix, name=name, atol=atol, rtol=rtol, timeout=timeout, **kwargs
         )

--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -1,21 +1,5 @@
 from ophyd import Device, Component, EpicsSignalWithRBV, EpicsSignalRO
-from enum import StrEnum
 from ophyd.pv_positioner import PVPositionerIsClose
-
-
-class MixFractionType(StrEnum):
-    """Enumeration of options for the `MixFractionType` PV."""
-
-    VOLUME_FRACTION = "Volume fraction"
-    MASS_FRACTION = "Mass fraction"
-    MOLE_FRACTION = "Mole fraction"
-
-
-class InitResetType(StrEnum):
-    """Enumeration of options for the `InitReset` PV."""
-
-    UNLOCKED = "unlocked"
-    LOCKED = "locked"
 
 
 class MFCMixFluid(Device):

--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -39,13 +39,13 @@ class MFC(PVPositionerDone):
     This class is initialized with its flow limits set to (0, 32000), following the manufacturer's recommendation.
     """
 
-    setpoint = Component(EpicsSignalWithRBV, "Setpoint", kind="config")
-    readback = Component(
-        EpicsSignalRO, "Measure_RBV", kind="hinted"
+    raw_setpoint = Component(EpicsSignalWithRBV, "Setpoint", kind="config")
+    raw_readback = Component(
+        EpicsSignalRO, "Measure_RBV", kind="config"
     )  # Dimensionless metered value of flow
 
-    fmeasure = Component(EpicsSignalRO, "FloatMeasure_RBV", kind="hinted")
-    fsetpoint = Component(EpicsSignalWithRBV, "FloatSetpoint", kind="config")
+    readback = Component(EpicsSignalRO, "FloatMeasure_RBV", kind="hinted")
+    setpoint = Component(EpicsSignalWithRBV, "FloatSetpoint", kind="config")
     capacity = Component(EpicsSignalWithRBV, "Capacity", kind="config")
     capacity_unit = Component(
         EpicsSignalWithRBV, "CapacityUnit", string=True, kind="config"

--- a/src/sophys/common/devices/mfc.py
+++ b/src/sophys/common/devices/mfc.py
@@ -1,28 +1,28 @@
 from ophyd import Device, Component, EpicsSignalWithRBV, EpicsSignalRO, EpicsSignal
-from bluesky.utils import FailedStatus
 from enum import StrEnum
 from ophyd.pv_positioner import PVPositionerDone
 
 
 class MixFractionType(StrEnum):
+    """Enumeration of options for the `MixFractionType` PV."""
+
     VOLUME_FRACTION = "Volume fraction"
     MASS_FRACTION = "Mass fraction"
     MOLE_FRACTION = "Mole fraction"
 
 
 class InitResetType(StrEnum):
+    """Enumeration of options for the `InitReset` PV."""
+
     UNLOCKED = "unlocked"
     LOCKED = "locked"
 
 
-class MFCFlowValueError(FailedStatus):
-    def __init__(self, value):
-        super().__init__(
-            f"The flow value {value} is out of range. The allowed range is between 0 and 32000"
-        )
-
-
 class MFCMixFluid(Device):
+    """
+    Device that aggragates the PVs with suffix `Mix` from the MFC's IOC. It's meant to be used as a `Component` for the `MFC` device.
+    """
+
     fluid_name_list = Component(
         EpicsSignal, "FluidNameList", string=True, kind="config"
     )
@@ -34,6 +34,11 @@ class MFCMixFluid(Device):
 
 
 class MFC(PVPositionerDone):
+    """
+    Bronkhorst's Prestige series Mass Flow Controller Ophyd device, with the `PVPositioner` interface.
+    This class is initialized with its flow limits set to (0, 32000), following the manufacturer's recommendation.
+    """
+
     setpoint = Component(EpicsSignalWithRBV, "Setpoint", kind="config")
     readback = Component(
         EpicsSignalRO, "Measure_RBV", kind="hinted"


### PR DESCRIPTION
`MFC` stands for Mass Flow Controller and it controls the flow rates within a gas/liquid system.
I'm attaching a reference pdf of the [device's manual](https://github.com/user-attachments/files/26821895/manual-el-flow-prestige.pdf). Pages 35-40 state that the devices from this family (EL-FLOW-Prestige) have a dimensionless flow measure and setpoint (the `Measure_RBV` and `Setpoint` PVs) ranging from 0 to 32000 (0 to 100% Capacity), and a fmeasure and fsetpoint (`FloatMeasure_RBV` and `FloatSetpoint` PVs) that represent the flow reading in the dimension set with the PV CapacityUnit and the maximum capacity (Capacity PV), so I tought it would be useful to have this PVs as well.
Another point I was thinking about including is an `Enum` for the available capacity units (age 43 of the manual). This would be a huge `Enum`, but at least we could include the most used, to facilitate setting this quantity.

<img width="857" height="837" alt="Screenshot From 2026-04-07 11-33-14" src="https://github.com/user-attachments/assets/141de455-c1c6-44f8-b504-3e7af7a4bb86" />
<img width="857" height="371" alt="Screenshot From 2026-04-07 11-33-45" src="https://github.com/user-attachments/assets/3a499a56-ca56-46f9-9bb6-51451ec9e125" />
<img width="857" height="614" alt="Screenshot From 2026-04-07 11-34-11" src="https://github.com/user-attachments/assets/76e3f6bc-3d6b-4c34-9111-82ddb688bc3c" />