### PR TITLE
Add numpydoc pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,8 @@ repos:
     rev: 7.1.0
     hooks:
     - id: flake8
+-   repo: https://github.com/numpy/numpydoc
+    rev: v1.10.0
+    hooks:
+    - id: numpydoc-validation
+      alias: numpydoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,6 @@ where = ["src"]
 [tool.flake8]
 max-line-length = 88
 extend-ignore = ["E203", "E704"]
+
+[tool.numpydoc_validation]
+checks = ["all", "EX01", "SA01", "ES01", "RT01"]


### PR DESCRIPTION
This should ensure our code documentation is maintained properly.

This hook is documented here:
https://numpydoc.readthedocs.io/en/latest/validation.html#

Currently our code-base has 572 errors related to these checks, most related to missing docstrings (GL08 - 383). This hook will only run for changed files, which means we can squash those errors with time. Fixing those errors also ensures the sphinx documentation parses those files properly.