### PR TITLE
Better propagate large run data from Kafka monitor

### DIFF
--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -4,6 +4,7 @@ import json
 from collections import defaultdict
 from datetime import timedelta
 from functools import wraps, partial
+from pathlib import Path
 from typing import Optional
 
 from threading import Thread, Event
@@ -134,6 +135,12 @@ class DocumentDictionary(dict):
     def get_raw_data(self):
         """Returns a JSON-formatted string representing the contents of this dictionary."""
         return json.dumps(dict.__repr__(self))
+
+    def save_to_json(self, path: Path):
+        """Save the document list as a JSON file in disk."""
+        path = path.with_suffix(".json")
+        with open(path, "w") as _f:
+            json.dump(self._original_stream, _f)
 
     @classmethod
     def fromJSON(cls, path):
@@ -383,7 +390,10 @@ class MonitorBase(KafkaConsumer):
             for id in self.__to_save_documents:
                 doc = self.__documents.get_by_identifier(id)
                 try:
-                    self.__save_queue.put(doc, block=True, timeout=1.0)
+                    temp_save_path = Path(f"/tmp/{id}.json")
+                    doc.save_to_json(temp_save_path)
+
+                    self.__save_queue.put(temp_save_path, block=True, timeout=1.0)
                     self.__saved_document_uids.add(id)
                 except Exception as e:
                     if isinstance(e, QueueFullException):

--- a/src/sophys/common/utils/kafka/monitor.py
+++ b/src/sophys/common/utils/kafka/monitor.py
@@ -11,12 +11,20 @@ from threading import Thread, Event
 from queue import Full as QueueFullException, Queue
 
 import msgpack_numpy as _m
+import numpy as np
 
 from kafka import KafkaConsumer
 
 from event_model import EventPage, unpack_event_page
 
 from .consumer import seek_start_document, seek_back_in_time
+
+
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, np.ndarray):
+            return o.tolist()
+        return super().default(o)
 
 
 def _get_uid_from_event_data(event_data: dict):
@@ -140,7 +148,7 @@ class DocumentDictionary(dict):
         """Save the document list as a JSON file in disk."""
         path = path.with_suffix(".json")
         with open(path, "w") as _f:
-            json.dump(self._original_stream, _f)
+            json.dump(self._original_stream, _f, cls=NumpyEncoder)
 
     @classmethod
     def fromJSON(cls, path):

--- a/tests/utils/test_kafka_monitor.py
+++ b/tests/utils/test_kafka_monitor.py
@@ -5,7 +5,7 @@ import queue
 from ophyd.sim import hw
 from bluesky import RunEngine, plans as bp, plan_stubs as bps, preprocessors as bpp
 
-from sophys.common.utils.kafka.monitor import ThreadedMonitor
+from sophys.common.utils.kafka.monitor import ThreadedMonitor, DocumentDictionary
 
 from . import _wait
 
@@ -238,8 +238,10 @@ def test_basic_custom_plan(
 
     _wait(lambda: uid not in incomplete_documents)
 
-    docs = save_queue.get(True, timeout=2.0)
-    assert docs is not None
+    docs_path = save_queue.get(True, timeout=2.0)
+    assert docs_path is not None
+
+    docs = DocumentDictionary.fromJSON(docs_path)
 
     # One start doc, one descriptor doc, one event doc, one stop doc
     assert len(docs) == 4, docs.get_raw_data()
@@ -256,8 +258,10 @@ def test_basic_fly_plan(
 
     _wait(lambda: uid not in incomplete_documents)
 
-    docs = save_queue.get(True, timeout=2.0)
-    assert docs is not None
+    docs_path = save_queue.get(True, timeout=2.0)
+    assert docs_path is not None
+
+    docs = DocumentDictionary.fromJSON(docs_path)
 
     # One start doc, one descriptor doc, twenty event doc (from 1 EventPage), one stop doc
     assert len(docs) == 23, docs.get_raw_data()
@@ -283,8 +287,10 @@ def test_basic_custom_plan_with_two_descriptor_documents(
 
     _wait(lambda: uid not in incomplete_documents)
 
-    docs = save_queue.get(True, timeout=2.0)
-    assert docs is not None
+    docs_path = save_queue.get(True, timeout=2.0)
+    assert docs_path is not None
+
+    docs = DocumentDictionary.fromJSON(docs_path)
 
     # One start doc, two descriptor doc, three event doc, one stop doc
     assert len(docs) == 7, docs.get_raw_data()
@@ -309,14 +315,18 @@ def test_basic_custom_plan_with_two_nested_runs(
 
     _wait(lambda: uid not in incomplete_documents)
 
-    docs = save_queue.get(True, timeout=2.0)
-    assert docs is not None
+    docs_path = save_queue.get(True, timeout=2.0)
+    assert docs_path is not None
+
+    docs = DocumentDictionary.fromJSON(docs_path)
 
     # One start doc, one descriptor doc, two event doc, one stop doc
     assert len(docs) == 5, docs.get_raw_data()
 
-    docs = save_queue.get(True, timeout=2.0)
-    assert docs is not None
+    docs_path = save_queue.get(True, timeout=2.0)
+    assert docs_path is not None
+
+    docs = DocumentDictionary.fromJSON(docs_path)
 
     # One start doc, one descriptor doc, one event doc, one stop doc
     assert len(docs) == 4, docs.get_raw_data()


### PR DESCRIPTION
This avoids hitting a memory limit when transferring large files from the monitor to a saver. Instead, we save the stream directly to a JSON file on disk, and pass on the path of the saved file.

It seems like the limitation we're encountering is from the multiprocessing module itself: https://docs.python.org/3/library/multiprocessing.html#multiprocessing.connection.Connection.send.