### PR TITLE
Add retry utility for plans, and a `mv_with_retry` plan stub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,4 @@ extend-ignore = ["E203", "E704"]
 
 [tool.numpydoc_validation]
 checks = ["all", "EX01", "SA01", "ES01", "RT01"]
+exclude_files = ["^tests/.*"]

--- a/src/sophys/common/plans/__init__.py
+++ b/src/sophys/common/plans/__init__.py
@@ -17,7 +17,7 @@ def _with_retry_decorator(func):  # numpydoc ignore=PR01
     from functools import wraps
 
     @wraps(func)
-    def __inner(*args, retry_count=3, ignore_warning=False):  # numpydoc ignore=PR01
+    def __inner(*args, max_attempts=3, ignore_warning=False):  # numpydoc ignore=PR01
         """Inner handler for dealing with plan retries."""
         _ret = None
 
@@ -30,11 +30,11 @@ def _with_retry_decorator(func):  # numpydoc ignore=PR01
         while True:
             try:
                 _ret = yield from func(*args)
-            except FailedStatus as e:
+            except FailedStatus:
                 retries += 1
 
-                if retries >= retry_count:
-                    raise e
+                if retries >= max_attempts:
+                    raise
             else:
                 break
 
@@ -44,7 +44,7 @@ def _with_retry_decorator(func):  # numpydoc ignore=PR01
 
 
 @_with_retry_decorator
-def mv_with_retry(*args):  # numpydoc ignore=PR02
+def mv_with_retry(*args, **kwargs):  # numpydoc ignore=PR02
     """
     A wrapper around ``bps.mv``, retrying the move if it fails.
 
@@ -52,8 +52,10 @@ def mv_with_retry(*args):  # numpydoc ignore=PR02
     ----------
     *args
         Arguments to plan_stubs.mv.
-    retry_count : int, optional
-        Maximum amount of retries before failing the move. Defaults to 3.
+    **kwargs
+        Keyword arguments to plan_stubs.mv.
+    max_attempts : int, optional
+        Maximum amount of attempts before failing the move. Defaults to 3.
     ignore_warning : bool, optional
         Ignore the 'not encouraged' warning on every usage. False by default.
 
@@ -61,4 +63,4 @@ def mv_with_retry(*args):  # numpydoc ignore=PR02
     --------
     bluesky.plan_stubs.mv : Base move plan stub.
     """
-    return (yield from bps.mv(*args))
+    return (yield from bps.mv(*args, **kwargs))

--- a/src/sophys/common/plans/__init__.py
+++ b/src/sophys/common/plans/__init__.py
@@ -1,1 +1,50 @@
-from .cumulative_scans import *
+from .cumulative_scans import *  # noqa: F403  numpydoc ignore=GL08
+
+
+from bluesky import plan_stubs as bps
+from bluesky.utils import FailedStatus
+
+
+def _with_retry_decorator(func):  # numpydoc ignore=PR01
+    """Decorator for adding retries to an arbitrary Bluesky plan."""
+    from functools import wraps
+
+    @wraps(func)
+    def __inner(*args, retry_count=3):  # numpydoc ignore=PR01
+        """Inner handler for dealing with plan retries."""
+        _ret = None
+
+        retries = 0
+        while True:
+            try:
+                _ret = yield from func(*args)
+            except FailedStatus as e:
+                retries += 1
+
+                if retries >= retry_count:
+                    raise e
+            else:
+                break
+
+        return _ret
+
+    return __inner
+
+
+@_with_retry_decorator
+def mv_with_retry(*args):  # numpydoc ignore=PR02
+    """
+    A wrapper around ``bps.mv``, retrying the move if it fails.
+
+    Parameters
+    ----------
+    *args
+        Arguments to plan_stubs.mv.
+    retry_count : int, optional
+        Maximum amount of retries before failing the move. Defaults to 3.
+
+    See Also
+    --------
+    bluesky.plan_stubs.mv : Base move plan stub.
+    """
+    return (yield from bps.mv(*args))

--- a/src/sophys/common/plans/__init__.py
+++ b/src/sophys/common/plans/__init__.py
@@ -5,14 +5,26 @@ from bluesky import plan_stubs as bps
 from bluesky.utils import FailedStatus
 
 
+RETRY_WARNING_MESSAGE = """Calling a plan (%s) with retry on errors.
+This is not encouraged, as it can hide buggy behavior and increase dead times.
+If possible, fix the underlying issue to avoid needing a retry.
+Otherwise, to disable this warning, pass the `ignore_warning` keyword argument as True in the plan.
+"""
+
+
 def _with_retry_decorator(func):  # numpydoc ignore=PR01
     """Decorator for adding retries to an arbitrary Bluesky plan."""
     from functools import wraps
 
     @wraps(func)
-    def __inner(*args, retry_count=3):  # numpydoc ignore=PR01
+    def __inner(*args, retry_count=3, ignore_warning=False):  # numpydoc ignore=PR01
         """Inner handler for dealing with plan retries."""
         _ret = None
+
+        if not ignore_warning:
+            import warnings
+
+            warnings.warn(RETRY_WARNING_MESSAGE % func.__name__, RuntimeWarning)
 
         retries = 0
         while True:
@@ -42,6 +54,8 @@ def mv_with_retry(*args):  # numpydoc ignore=PR02
         Arguments to plan_stubs.mv.
     retry_count : int, optional
         Maximum amount of retries before failing the move. Defaults to 3.
+    ignore_warning : bool, optional
+        Ignore the 'not encouraged' warning on every usage. False by default.
 
     See Also
     --------

--- a/tests/plans/test_retry.py
+++ b/tests/plans/test_retry.py
@@ -53,7 +53,7 @@ def test_mv_with_retry():
 
     def plan_mv_with_retry():
         with pytest.warns(RuntimeWarning):
-            yield from mv_with_retry(signal, 3, retry_count=3)
+            yield from mv_with_retry(signal, 3, max_attempts=3)
         assert signal.get() == 3
 
     RE(plan_mv_with_retry())
@@ -65,7 +65,7 @@ def test_mv_with_retry():
         did_throw = False
         with pytest.warns(RuntimeWarning):
             try:
-                yield from mv_with_retry(signal, 4, retry_count=3)
+                yield from mv_with_retry(signal, 4, max_attempts=3)
             except FailedStatus:
                 did_throw = True
 
@@ -82,7 +82,7 @@ def test_mv_with_retry_ignore_warning():
     RE = RunEngine()
 
     def plan_mv_with_retry():
-        yield from mv_with_retry(signal, 3, retry_count=3, ignore_warning=True)
+        yield from mv_with_retry(signal, 3, max_attempts=3, ignore_warning=True)
         assert signal.get() == 3
 
     RE(plan_mv_with_retry())

--- a/tests/plans/test_retry.py
+++ b/tests/plans/test_retry.py
@@ -1,3 +1,5 @@
+import pytest
+
 from collections import defaultdict
 
 from bluesky import RunEngine, plan_stubs as bps
@@ -50,7 +52,8 @@ def test_mv_with_retry():
     assert signal.get() == 0
 
     def plan_mv_with_retry():
-        yield from mv_with_retry(signal, 3, retry_count=3)
+        with pytest.warns(RuntimeWarning):
+            yield from mv_with_retry(signal, 3, retry_count=3)
         assert signal.get() == 3
 
     RE(plan_mv_with_retry())
@@ -60,12 +63,26 @@ def test_mv_with_retry():
 
     def plan_mv_with_not_enough_retries():
         did_throw = False
-        try:
-            yield from mv_with_retry(signal, 4, retry_count=3)
-        except FailedStatus:
-            did_throw = True
+        with pytest.warns(RuntimeWarning):
+            try:
+                yield from mv_with_retry(signal, 4, retry_count=3)
+            except FailedStatus:
+                did_throw = True
 
         assert signal.get() == 0
         assert did_throw
 
     RE(plan_mv_with_not_enough_retries())
+
+
+@pytest.mark.filterwarnings("error")
+def test_mv_with_retry_ignore_warning():
+    signal = FailfulSignal(name="sig")
+
+    RE = RunEngine()
+
+    def plan_mv_with_retry():
+        yield from mv_with_retry(signal, 3, retry_count=3, ignore_warning=True)
+        assert signal.get() == 3
+
+    RE(plan_mv_with_retry())

--- a/tests/plans/test_retry.py
+++ b/tests/plans/test_retry.py
@@ -1,0 +1,71 @@
+from collections import defaultdict
+
+from bluesky import RunEngine, plan_stubs as bps
+from bluesky.utils import FailedStatus
+
+from ophyd import Signal
+
+from sophys.common.plans import mv_with_retry
+
+
+class FailfulSignal(Signal):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._attempts = defaultdict(lambda: 0)
+
+    def reset(self):
+        self._attempts.clear()
+        super().put(0)
+
+    def put(self, value, **kwargs):
+        self._attempts[value] += 1
+
+        if self._attempts[value] >= value:
+            return super().put(value, **kwargs)
+
+    def set(self, value, **kwargs):
+        return super().set(value, timeout=0.2, **kwargs)
+
+
+def test_mv_with_retry():
+    signal = FailfulSignal(name="sig")
+
+    RE = RunEngine()
+
+    def plan_mv():
+        try:
+            yield from bps.abs_set(signal, 2, wait=True)
+        except FailedStatus:
+            pass
+
+        assert signal.get() == 0
+
+        yield from bps.mv(signal, 2)
+        assert signal.get() == 2
+
+    RE(plan_mv())
+
+    signal.reset()
+    assert signal.get() == 0
+
+    def plan_mv_with_retry():
+        yield from mv_with_retry(signal, 3, retry_count=3)
+        assert signal.get() == 3
+
+    RE(plan_mv_with_retry())
+
+    signal.reset()
+    assert signal.get() == 0
+
+    def plan_mv_with_not_enough_retries():
+        did_throw = False
+        try:
+            yield from mv_with_retry(signal, 4, retry_count=3)
+        except FailedStatus:
+            did_throw = True
+
+        assert signal.get() == 0
+        assert did_throw
+
+    RE(plan_mv_with_not_enough_retries())


### PR DESCRIPTION
These seem to be commonly needed, so I added a sample implementation, along with automated tests to make them more robust than ad-hoc implementations scattered throughout different beamlines.

Note that the test will have some junk teardown tracebacks on `bluesky < 1.15.0`, due to [this fix missing](https://github.com/bluesky/bluesky/commit/99560f647c733b1b0f0e10f783e6494919b6d6fa), but the test still works fine.