### PR TITLE
Start structuring ophyd-async usage across the sophys project

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Install package
-        run: pip install ".[all]"
+        run: pip install ".[all]" && pip install aioca
       - name: Run Kafka
         uses: spicyparrot/kafka-kraft-action@v1.1.3
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Setup Python
         uses: actions/setup-python@v5.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,17 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 24.4.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
     hooks:
-    - id: black
-      language_version: python3
--   repo: https://github.com/pyCQA/flake8
-    rev: 7.1.0
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
-    - id: flake8
--   repo: https://github.com/numpy/numpydoc
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/numpy/numpydoc
     rev: v1.10.0
     hooks:
     - id: numpydoc-validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = ["version"]
 dependencies = [
   "bluesky",
   "ophyd",
-  "ophyd-async",
+  "ophyd-async~=0.21.1",
   "numpy",
   "requests",
   "strenum ; python_version < '3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dynamic = ["version"]
 dependencies = [
   "bluesky",
   "ophyd",
+  "ophyd-async",
   "numpy",
   "requests",
   "strenum ; python_version < '3.11'",
@@ -34,6 +35,7 @@ dependencies = [
 dev = [
   "pre-commit",
   "pytest",
+  "pytest-asyncio",
   "pytest-cov",
   "pytest-virtualenv",
   "caproto!=1.2.0",
@@ -64,4 +66,10 @@ extend-ignore = ["E203", "E704"]
 
 [tool.numpydoc_validation]
 checks = ["all", "EX01", "SA01", "ES01", "RT01"]
+<<<<<<< HEAD
 exclude_files = ["^tests/.*"]
+=======
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+>>>>>>> 517bcee (meta: add ophyd-async basic requirements)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "bluesky",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
   "pytest",
   "pytest-asyncio",
   "pytest-cov",
+  "pytest-timeout",
   "pytest-virtualenv",
   "caproto!=1.2.0",
 ]
@@ -64,17 +65,14 @@ exclude = ["__version__.py", "docs/*"]
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "N", "B", "UP"]
-ignore = ["E203", "E501", "N817"]
+ignore = ["E203", "E501", "N806", "N817"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]  # Ignore assert warnings in test files
 
 [tool.numpydoc_validation]
 checks = ["all", "EX01", "SA01", "ES01", "RT01"]
-<<<<<<< HEAD
 exclude_files = ["^tests/.*"]
-=======
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
->>>>>>> 517bcee (meta: add ophyd-async basic requirements)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,15 @@ version_file = "src/sophys/common/__version__.py"
 [tool.setuptools.packages.find]
 where = ["src"]
 
-# https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#flake8
-[tool.flake8]
-max-line-length = 88
-extend-ignore = ["E203", "E704"]
+[tool.ruff]
+exclude = ["__version__.py", "docs/*"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "N", "B", "UP"]
+ignore = ["E203", "E501", "N817"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101"]  # Ignore assert warnings in test files
 
 [tool.numpydoc_validation]
 checks = ["all", "EX01", "SA01", "ES01", "RT01"]

--- a/src/sophys/common/devices/async_positioner.py
+++ b/src/sophys/common/devices/async_positioner.py
@@ -1,0 +1,97 @@
+# numpydoc ignore=GL08
+import asyncio
+import functools
+
+from typing import TypeVar, Generic, cast
+
+import numpy as np
+
+from ophyd_async.core import (
+    AsyncStatus,
+    SignalR,
+    SignalW,
+    SignalRW,
+    StandardReadable,
+    WatchableAsyncStatus,
+    WatcherUpdate,
+    Ignore,
+    observe_value,
+    DEFAULT_TIMEOUT,
+)
+
+from bluesky.protocols import Reading
+
+
+T = TypeVar("T", bound=int | float)
+
+
+class BasePositioner(StandardReadable, Generic[T]):
+    """
+    Base class for a positioner device in ophyd-async.
+
+    This works similarly to the PVPositioner* devices in regular ophyd.
+    """
+
+    readback: SignalR[T]
+    setpoint: SignalRW[T]
+
+    actuate: SignalW[float] | Ignore
+    actuate_value: float = 1.0
+
+    done: SignalR[float] | Ignore
+    done_value: float = 1.0
+
+    atol: float = 1.0e-8
+    rtol: float = 1.0e-5
+
+    def set_name(
+        self, name: str, *, child_name_separator: str | None = None
+    ) -> None:  # numpydoc ignore=GL08
+        super().set_name(name, child_name_separator=child_name_separator)
+
+        self.readback.set_name(name)
+
+    def _check_done_signal(  # numpydoc ignore=GL08
+        self, reading: dict[str, Reading], is_done_event: asyncio.Event
+    ):
+        if reading[cast(SignalR, self.done).name]["value"] == self.done_value:
+            is_done_event.set()
+
+    @WatchableAsyncStatus.wrap
+    async def set(self, value: float, timeout=DEFAULT_TIMEOUT):  # numpydoc ignore=PR01
+        """Send the positioner to a new position."""
+        initial_value = await self.readback.get_value()
+
+        await self.setpoint.set(value)
+
+        if hasattr(self, "actuate"):
+            await cast(SignalW, self.actuate).set(self.actuate_value)
+
+        is_done_signal_done = asyncio.Event()
+
+        done_status = None
+        if hasattr(self, "done"):
+            cast(SignalR, self.done).subscribe_reading(
+                functools.partial(
+                    self._check_done_signal, is_done_event=is_done_signal_done
+                )
+            )
+            done_status = AsyncStatus(is_done_signal_done.wait())
+        else:
+            is_done_signal_done.set()
+
+        async for current_value in observe_value(
+            self.readback, done_status=done_status, done_timeout=timeout
+        ):
+            yield WatcherUpdate(
+                current=current_value,
+                initial=initial_value,
+                target=value,
+                name=self.name,
+            )
+
+            if (
+                np.isclose(current_value, value, atol=self.atol, rtol=self.rtol)
+                and is_done_signal_done.is_set()
+            ):
+                break

--- a/src/sophys/common/utils/packages.py
+++ b/src/sophys/common/utils/packages.py
@@ -13,7 +13,7 @@ from urllib.parse import urlsplit, SplitResult
 from requests import get as http_get, Response as HttpResponse
 import tempfile
 
-from typing_extensions import Unpack, cast
+from typing import cast
 
 try:
     from enum import StrEnum
@@ -101,7 +101,7 @@ def _run_command(
         print("  Standard error:")
         print(e.stderr)
 
-        raise RuntimeError
+        raise RuntimeError from e
 
     return _proc
 

--- a/src/sophys/common/utils/packages.py
+++ b/src/sophys/common/utils/packages.py
@@ -106,17 +106,17 @@ def _run_command(
     return _proc
 
 
-StrSequenceType: typing.TypeAlias = typing.Tuple[str, ...]
+StrSequenceType: typing.TypeAlias = tuple[str, ...]
 
 
 def install_packages(
-    *package_specs: Unpack[StrSequenceType],
-    extra_index_url: typing.Optional[list[str]] = None,
+    *package_specs: *StrSequenceType,
+    extra_index_url: list[str] | None = None,
     force_reinstall: bool = False,
     disable_cache: bool = False,
     debug: bool = False,
     backend: PackageManagementBackend | str = PackageManagementBackend.PIP,
-    custom_python_executable: typing.Optional[str] = None,
+    custom_python_executable: str | None = None,
 ):
     """
     Install a package in the current environment.

--- a/src/sophys/common/utils/registry.py
+++ b/src/sophys/common/utils/registry.py
@@ -1,3 +1,5 @@
+"""Module for dealing with device registries (storing and retrieving devices)."""
+
 from itertools import chain
 import logging
 from contextlib import contextmanager
@@ -13,11 +15,13 @@ __auto_register = threading.local()
 
 
 def in_autoregister_context() -> bool:
-    """Returns whether the current execution context is auto registering new devices to a registry."""
+    """Return whether the current execution context is auto registering new devices to a registry."""
     return hasattr(__auto_register, "val") and __auto_register.val is not None
 
 
-def get_named_registry(registry_name: str, create_if_missing: bool = False):
+def get_named_registry(
+    registry_name: str, create_if_missing: bool = False
+):  # numpydoc ignore=PR01
     """
     Get the instance of ophyd-registry's Registry associated with ``register_name``.
 
@@ -38,7 +42,7 @@ def get_named_registry(registry_name: str, create_if_missing: bool = False):
     return __global_registries.get(registry_name)
 
 
-def create_named_registry(registry_name: str):
+def create_named_registry(registry_name: str):  # numpydoc ignore=PR01
     """
     Create a new Registry associated with ``registry_name``, clearing an existing one if it does.
 
@@ -78,7 +82,7 @@ def create_named_registry(registry_name: str):
         return registry
 
 
-def get_registry_name(registry):
+def get_registry_name(registry):  # numpydoc ignore=PR01
     """Return the name associated with this registry."""
     global __global_registry_names
     return __global_registry_names[registry]
@@ -99,6 +103,8 @@ def get_all_root_devices(as_dict: bool = False, use_registry_name: bool = True):
     as_dict : bool, optional
         If True, return a dictionary, as per :func:`to_variable_dict`.
         Otherwise, return a list of all root devices. Defaults to False.
+    use_registry_name : bool, optional
+        If True, prepend the registry name to the name of the retrieved devices.
     """
     registries = get_all_registries()
 
@@ -159,12 +165,48 @@ def get_all_devices(
 
 
 def find_all(
-    any_of: typing.Optional[str] = None,
+    any_of: str | None = None,
     *,
-    label: typing.Optional[str] = None,
-    name: typing.Optional[str] = None,
-    allow_none: typing.Optional[bool] = False,
-):
+    label: str | None = None,
+    name: str | None = None,
+    allow_none: bool = False,
+) -> list:
+    """
+    Find registered device components matching parameters.
+
+    Combining search terms works in an *or* fashion. For example,
+    ``findall(name="my_device", label="ion_chambers")`` will find
+    all devices that have either the name "my_device" or a label
+    "ion_chambers".
+
+    The *any_of* keyword is a proxy for all the other keywords. For
+    example ``findall(any_of="my_device")`` is equivalent to
+    ``findall(name="my_device", label="my_device")``.
+
+    The name provided to *any_of*, *label*, or *name* can also
+    include dot-separated attributes after the device name. For
+    example, looking up ``name="eiger_500K.cam.gain"`` will look
+    up the device named "eiger_500K" then return the
+    Device.cam.gain attribute.
+
+    Parameters
+    ----------
+    any_of : str or None, optional
+      Search by either of the other parameters.
+    label : str or None, optional
+      Search by the component's ``labels={"my_label"}`` parameter.
+    name : str or None, optional
+      Search by the component's ``name="my_name"`` parameter.
+    allow_none : bool, optional
+      If False (default), missing components will raise an exception.
+      Otherwise, an empty list is returned if no registered components are found.
+
+    Raises
+    ------
+    ComponentNotFound
+      No component was found that matches the given search
+      parameters.
+    """
     res = list(
         chain.from_iterable(
             i.findall(any_of=any_of, label=label, name=name, allow_none=True)
@@ -176,15 +218,13 @@ def find_all(
         from ophydregistry.exceptions import ComponentNotFound
 
         raise ComponentNotFound(
-            'Could not find components matching: label="{}", name="{}"'.format(
-                label or any_of, name or any_of
-            )
+            f'Could not find components matching: label="{label or any_of}", name="{name or any_of}"'
         )
 
     return res
 
 
-def remove_all_named(name: str):
+def remove_all_named(name: str):  # numpydoc ignore=PR01
     """Remove all devices with a given name from all registries."""
     registries = get_all_registries()
 
@@ -196,7 +236,7 @@ def remove_all_named(name: str):
 
 
 @contextmanager
-def register_devices(registry_name: str):
+def register_devices(registry_name: str):  # numpydoc ignore=PR01,YD01
     """
     Context Manager for registering instantiated devices inside it to ``registry_name``.
 
@@ -225,15 +265,125 @@ def register_devices(registry_name: str):
     __auto_register.val = None
 
 
+def register_async_devices(
+    registry_name: str,
+    *,
+    labels: typing.Sequence[str] | None = None,
+    set_name: bool = True,
+    child_name_separator: str = "-",
+    connect: bool = True,
+    mock: bool = False,
+    timeout: float = 10.0,
+    raise_on_error: bool = False,
+):
+    """
+    Return a context manager for registering instantiated async devices inside it to ``registry_name``.
+
+    For instance, to register devices ``a`` and ``b`` to registry ``beamline_a``,
+    and devices ``c``, ``d``, and ``e`` to registry ``beamline_b``, you could do something like:
+
+    .. code-block:: python
+
+        # ...
+
+        with register_async_devices("beamline_a", mock=True):
+            DeviceAClass(name="a")
+            DeviceBClass(name="b")
+
+        with register_async_devices("beamline_b", mock=False):
+            DeviceCClass(name="c")
+            DeviceDClass(name="d")
+            DeviceEClass(name="e")
+
+    Parameters
+    ----------
+    registry_name : str
+        Name of the registry in which all devices inside the context manager will be added to.
+    labels : sequence of str or None, optional
+        Optional labels to include for every instantiated device inside the context.
+    set_name : bool, optional
+        See ``ophyd_async.core.init_devices`` for more details.
+    child_name_separator : str, optional
+        See ``ophyd_async.core.init_devices`` for more details.
+    connect : bool, optional
+        See ``ophyd_async.core.init_devices`` for more details.
+    mock : bool, optional
+        See ``ophyd_async.core.init_devices`` for more details.
+    timeout : float, optional
+        See ``ophyd_async.core.init_devices`` for more details.
+    raise_on_error : bool, optional
+        Raise an exception if some device failed to connect (if connect=True). Otherwise,
+        ignore any such exceptions. Defaults to ignore (False).
+    """
+    from ophydregistry import Registry
+
+    registry: Registry = get_named_registry(
+        registry_name, True
+    )  # Ensure the registry exists without clearing it if it does.
+
+    from ophyd_async.core import wait_for_connection, Device, NotConnectedError
+    from ophyd_async.core._device import DeviceProcessor
+
+    async def process_devices(devices: dict[str, Device]):  # numpydoc ignore=PR01
+        """Inner implementation of `init_devices` suited for interacting with ophyd-registry."""
+        add_all_devices = True
+
+        if set_name:
+            for name, device in devices.items():
+                if not device.name:
+                    device.set_name(name, child_name_separator=child_name_separator)
+        if connect:
+            coros = {
+                name: device.connect(mock, timeout) for name, device in devices.items()
+            }
+
+            try:
+                await wait_for_connection(**coros)
+            except NotConnectedError:
+                add_all_devices = False
+                for device in devices.values():
+                    if device._connect_task is None:
+                        continue
+
+                    success = (
+                        device._connect_task.done()
+                        and device._connect_task.exception() is None
+                    )
+
+                    if success:
+                        registry.register(device, labels)
+
+                if raise_on_error:
+                    raise
+
+        if add_all_devices:
+            for device in devices.values():
+                registry.register(device, labels)
+
+    return DeviceProcessor(process_devices)
+
+
 def to_variable_dict(registries: typing.Iterable, use_registry_name: bool = True):
     """
-    Turns a registry (or set of registries) into a dictionary, intended of being used as such:
+    Turn a registry (or set of registries) into a dictionary.
+
+    Intended of being used as such:
 
     - ``globals().update(<return value>)``
     - ``locals().update(<return value>)``
+
+    Parameters
+    ----------
+    registries : iterable of Registry objects
+        Construct the return dictionary using all devices from all registries set.
+    use_registry_name : bool, optional
+        If True, prepend the containing registry name to the device's
+        name in the dict key. Defaults to True.
     """
 
-    def process_name(registry, name: str, use_registry_name: bool = True):
+    def process_name(
+        registry, name: str, use_registry_name: bool = True
+    ):  # numpydoc ignore=GL08
         pattern = re.compile("[^a-zA-Z0-9_]")
         clear_name = functools.partial(re.sub, pattern, "_")
 
@@ -241,7 +391,7 @@ def to_variable_dict(registries: typing.Iterable, use_registry_name: bool = True
         registry_name = clear_name(get_registry_name(registry))
 
         if use_registry_name:
-            return "{}_{}".format(registry_name, device_name)
+            return f"{registry_name}_{device_name}"
         return device_name
 
     ret = {}

--- a/src/sophys/common/utils/registry.py
+++ b/src/sophys/common/utils/registry.py
@@ -339,18 +339,10 @@ def register_async_devices(
 
             try:
                 await wait_for_connection(**coros)
-            except NotConnectedError:
+            except NotConnectedError as exc:
                 add_all_devices = False
-                for device in devices.values():
-                    if device._connect_task is None:
-                        continue
-
-                    success = (
-                        device._connect_task.done()
-                        and device._connect_task.exception() is None
-                    )
-
-                    if success:
+                for name, device in devices.items():
+                    if name not in exc.sub_errors:
                         registry.register(device, labels)
 
                 if raise_on_error:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,16 @@ from .soft_ioc import start_soft_ioc
 def soft_ioc():
     soft_ioc_prefix, stop_soft_ioc = start_soft_ioc()
     yield soft_ioc_prefix
+
+    try:
+        from aioca import purge_channel_caches
+
+        # Purge the channel caches before we stop the IOC to stop
+        # RuntimeError: Event loop is closed errors on teardown
+        purge_channel_caches()
+    except ImportError:
+        pass
+
     stop_soft_ioc()
 
 

--- a/tests/devices/test_async_instantiation.py
+++ b/tests/devices/test_async_instantiation.py
@@ -1,0 +1,117 @@
+import sys
+
+import pytest
+
+from ophyd_async.core import init_devices, NotConnectedError
+from ophyd_async.epics.motor import Motor
+
+from sophys.common.utils.registry import register_async_devices, get_named_registry
+
+
+@pytest.mark.timeout(0.5)
+async def test_single_mock_instantiation():
+    async with init_devices(mock=True, timeout=1.0):
+        _ = Motor("SOMETHING:NON:EXISTENT")
+
+
+@pytest.mark.timeout(0.5)
+async def test_multiple_mock_instantiations():
+    async with init_devices(mock=True, timeout=1.0):
+        _1 = Motor("SOMETHING:NON:EXISTENT")
+        _2 = Motor("SOMETHING:NON:EXISTENT")
+
+
+@pytest.mark.timeout(1.5)
+async def test_single_instantiation():
+    with pytest.raises(NotConnectedError):
+        async with init_devices(timeout=1.0):
+            _ = Motor("SOMETHING:NON:EXISTENT")
+
+
+@pytest.mark.timeout(2.5)
+async def test_multiple_instantiations():
+    with pytest.raises(NotConnectedError):
+        async with init_devices(timeout=1.0):
+            _1 = Motor("SOMETHING:NON:EXISTENT")
+            _2 = Motor("SOMETHING:NON:EXISTENT")
+
+
+@pytest.mark.timeout(1.5)
+async def test_many_instantiations_parallel():
+    with pytest.raises(NotConnectedError):
+        async with init_devices(timeout=1.0):
+            # NOTE: The try..except is there to generate an exception context we can use to retrieve the current stack frame
+            try:
+                raise ValueError
+            except ValueError:
+                _, _, tb = sys.exc_info()
+                assert tb is not None
+                current_frame = tb.tb_frame
+
+                for x in range(100):
+                    current_frame.f_locals[f"_{x}"] = Motor("SOMETHING:NON:EXISTENT")
+
+
+@pytest.mark.timeout(1.5)
+class TestRegistry:
+    @pytest.fixture(autouse=True)
+    def clean_registry_on_cleanup(self):
+        yield
+        get_named_registry("TEST", False).clear()
+
+    async def test_registry_instantiation_with_timeout(self):
+        with pytest.raises(NotConnectedError):
+            async with register_async_devices("TEST", timeout=1.0, raise_on_error=True):
+                _ = Motor("SOMETHING:NON:EXISTENT")
+
+    async def test_registry_instantiation(self):
+        async with register_async_devices(
+            "TEST", timeout=1.0, mock=True, raise_on_error=True
+        ):
+            my_motor = Motor("SOMETHING:NON:EXISTENT")
+
+        registry = get_named_registry("TEST")
+        assert registry is not None
+        assert registry.find(name="my_motor") is my_motor
+
+    async def test_registry_instantiation_twice(self):
+        async with register_async_devices(
+            "TEST", timeout=1.0, mock=True, raise_on_error=True
+        ):
+            my_motor_1 = Motor("SOMETHING:NON:EXISTENT")
+        async with register_async_devices(
+            "TEST", timeout=1.0, mock=True, raise_on_error=True
+        ):
+            my_motor_2 = Motor("SOMETHING:NON:EXISTENT")
+
+        registry = get_named_registry("TEST")
+        assert registry is not None
+        assert registry.find(name="my_motor_1") is my_motor_1
+        assert registry.find(name="my_motor_2") is my_motor_2
+
+    async def test_registry_instantiation_with_partial_timeout(self, soft_ioc):
+        async with register_async_devices("TEST", timeout=1.0):
+            my_motor_1 = Motor(soft_ioc + "SLIT:TOP")
+            my_motor_2 = Motor("SOMETHING:NON:EXISTENT")
+            # Just to check if the timeout time remains low
+            _ = Motor("SOMETHING:NON:EXISTENT")
+
+        registry = get_named_registry("TEST")
+        assert registry is not None
+        assert registry.find(name="my_motor_1") is my_motor_1
+        assert registry.find(name="my_motor_2", allow_none=True) is not my_motor_2
+        assert registry.find(name="my_motor_2", allow_none=True) is None
+
+    async def test_registry_instantiation_with_partial_timeout_and_exc(self, soft_ioc):
+        with pytest.raises(NotConnectedError):
+            async with register_async_devices("TEST", timeout=1.0, raise_on_error=True):
+                my_motor_1 = Motor(soft_ioc + "SLIT:TOP")
+                my_motor_2 = Motor("SOMETHING:NON:EXISTENT")
+                # Just to check if the timeout time remains low
+                _ = Motor("SOMETHING:NON:EXISTENT")
+
+        registry = get_named_registry("TEST")
+        assert registry is not None
+        assert registry.find(name="my_motor_1") is my_motor_1
+        assert registry.find(name="my_motor_2", allow_none=True) is not my_motor_2
+        assert registry.find(name="my_motor_2", allow_none=True) is None

--- a/tests/devices/test_async_instantiation.py
+++ b/tests/devices/test_async_instantiation.py
@@ -8,6 +8,14 @@ from ophyd_async.epics.motor import Motor
 from sophys.common.utils.registry import register_async_devices, get_named_registry
 
 
+@pytest.fixture(scope="session", autouse=True)
+def skip_if_aioca_not_present():
+    pytest.importorskip(
+        "aioca",
+        reason="Package 'aioca' is not installed, and is required for the ophyd-async tests.",
+    )
+
+
 @pytest.mark.timeout(0.5)
 async def test_single_mock_instantiation():
     async with init_devices(mock=True, timeout=1.0):

--- a/tests/devices/test_async_positioner.py
+++ b/tests/devices/test_async_positioner.py
@@ -1,0 +1,187 @@
+import pytest
+
+import asyncio
+
+from typing import Annotated as A
+from unittest.mock import ANY
+
+from ophyd_async.core import init_devices, set_mock_value, SignalR, SignalRW
+from ophyd_async.core import StandardReadableFormat as Format
+from ophyd_async.epics.core import EpicsDevice, PvSuffix as Pv
+from ophyd_async.testing import (
+    StatusWatcher,
+    assert_reading,
+    assert_value,
+    wait_for_pending_wakeups,
+)
+
+from sophys.common.devices.async_positioner import BasePositioner
+
+
+async def _test_positioner_movement(
+    positioner: BasePositioner,
+    before_set_func=None,
+    after_set_func=None,
+    before_end_func=None,
+    initial_pos: float = 0.0,
+    final_pos: float = 1.0,
+):
+    if before_set_func is not None:
+        await before_set_func()
+    s = positioner.set(final_pos)
+
+    watcher = StatusWatcher(s)
+    await watcher.wait_for_call(
+        name=positioner.name,
+        current=initial_pos,
+        initial=initial_pos,
+        target=final_pos,
+        time_elapsed=ANY,
+    )
+    # Wait a bit and give it an update, checking that the watcher is called with it
+    await asyncio.sleep(0.1)
+
+    await assert_value(positioner.setpoint, final_pos)
+    assert not s.done
+
+    if after_set_func is not None:
+        await after_set_func(s)
+
+    set_mock_value(positioner.readback, (final_pos - initial_pos) / 2)
+    await watcher.wait_for_call(
+        name=positioner.name,
+        current=(final_pos - initial_pos) / 2,
+        initial=initial_pos,
+        target=final_pos,
+        time_elapsed=ANY,
+    )
+
+    # Make it almost get there and check that it completes
+    set_mock_value(positioner.readback, final_pos - 1e-9)
+    await wait_for_pending_wakeups()
+
+    if before_end_func is not None:
+        await before_end_func(s)
+        await wait_for_pending_wakeups()
+
+    assert s.done
+    assert s.success
+
+
+class _SimpleMockPositioner(BasePositioner, EpicsDevice):
+    readback: A[SignalR[float], Pv("Readback"), Format.HINTED_SIGNAL]
+    setpoint: A[SignalRW[float], Pv("Setpoint")]
+
+
+@pytest.fixture
+async def simple_mock_positioner():
+    async with init_devices(mock=True):
+        simple_mock_positioner = _SimpleMockPositioner("PV:TEST:")
+
+    set_mock_value(simple_mock_positioner.readback, 0.0)
+    set_mock_value(simple_mock_positioner.setpoint, 0.0)
+
+    yield simple_mock_positioner
+
+
+async def test_simple_positioner(simple_mock_positioner):
+    set_mock_value(simple_mock_positioner.readback, 0.5)
+    await assert_value(simple_mock_positioner.readback, 0.5)
+    await assert_reading(
+        simple_mock_positioner,
+        {
+            "simple_mock_positioner": {
+                "value": 0.5,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            }
+        },
+    )
+
+    set_mock_value(simple_mock_positioner.readback, 0.0)
+    await assert_value(simple_mock_positioner.readback, 0.0)
+    await assert_reading(
+        simple_mock_positioner,
+        {
+            "simple_mock_positioner": {
+                "value": 0.0,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            }
+        },
+    )
+
+    await _test_positioner_movement(simple_mock_positioner)
+
+
+class _MockPositionerWithActuator(BasePositioner, EpicsDevice):
+    readback: A[SignalR[float], Pv("Readback"), Format.HINTED_SIGNAL]
+    setpoint: A[SignalRW[float], Pv("Setpoint")]
+
+    actuate: A[SignalRW[float], Pv("Actuate")]
+    actuate_value = 2.5
+
+
+@pytest.fixture
+async def mock_positioner_with_actuator():
+    async with init_devices(mock=True):
+        mock_positioner_with_actuator = _MockPositionerWithActuator("PV:TEST:")
+
+    set_mock_value(mock_positioner_with_actuator.readback, 0.0)
+    set_mock_value(mock_positioner_with_actuator.setpoint, 0.0)
+
+    yield mock_positioner_with_actuator
+
+
+async def test_positioner_with_actuator(mock_positioner_with_actuator):
+    async def before_set_func():
+        await assert_value(mock_positioner_with_actuator.actuate, 0.0)
+
+    async def after_set_func(s):
+        await assert_value(
+            mock_positioner_with_actuator.actuate,
+            mock_positioner_with_actuator.actuate_value,
+        )
+
+    await _test_positioner_movement(
+        mock_positioner_with_actuator, before_set_func, after_set_func
+    )
+
+
+class _MockPositionerWithDone(BasePositioner, EpicsDevice):
+    readback: A[SignalR[float], Pv("Readback"), Format.HINTED_SIGNAL]
+    setpoint: A[SignalRW[float], Pv("Setpoint")]
+
+    done: A[SignalRW[float], Pv("Done")]
+    done_value = 1.5
+
+
+@pytest.fixture
+async def mock_positioner_with_done():
+    async with init_devices(mock=True):
+        mock_positioner_with_done = _MockPositionerWithDone("PV:TEST:")
+
+    set_mock_value(mock_positioner_with_done.readback, 0.0)
+    set_mock_value(mock_positioner_with_done.setpoint, 0.0)
+
+    yield mock_positioner_with_done
+
+
+async def test_positioner_with_done(mock_positioner_with_done):
+    async def before_set_func():
+        await assert_value(mock_positioner_with_done.done, 0.0)
+
+    async def before_end_func(s):
+        assert not s.done
+
+        set_mock_value(
+            mock_positioner_with_done.done, mock_positioner_with_done.done_value
+        )
+
+    await _test_positioner_movement(
+        mock_positioner_with_done, before_set_func, None, before_end_func
+    )
+
+    await assert_value(
+        mock_positioner_with_done.done, mock_positioner_with_done.done_value
+    )

--- a/tests/devices/test_async_positioner.py
+++ b/tests/devices/test_async_positioner.py
@@ -18,6 +18,14 @@ from ophyd_async.testing import (
 from sophys.common.devices.async_positioner import BasePositioner
 
 
+@pytest.fixture(scope="session", autouse=True)
+def skip_if_aioca_not_present():
+    pytest.importorskip(
+        "aioca",
+        reason="Package 'aioca' is not installed, and is required for the ophyd-async tests.",
+    )
+
+
 async def _test_positioner_movement(
     positioner: BasePositioner,
     before_set_func=None,


### PR DESCRIPTION
This PR aims to provide the basic building blocks for us to start using ophyd-async in a more organized manner on SIRIUS. Suggestions and contributions are welcome as always.

The aim of this patch series is also to provide some foundational knowledge for how to interact with the new library, how to create new devices, how to use them, among other things. We could add a dedicated documentation page about these if we feel the need to, but a clear code serving as example of those things is also a form of documentation I strive to make this PR into.

TODO List:
- [X] Implement a proper substitute for `PVPositioner`
  - [ ] Desired: Inherit from the newly added `StandardMovable` class from ophyd-async (`>=v0.18`).
- [ ] Create a parallel flow for instantiation of ophyd-async devices
- [X] Adapt our usage of ophyd-registry to work with these new devices
	- NOTE: In the current implementation, I've accessed some private modules / attributes:

		-  `DeviceProcessor` from `ophyd_async.core._device` - Customize the callback implementation to interact with `ophyd-registry`. Can dealt with by https://github.com/bluesky/ophyd-async/pull/1293, if it gets merged.
		- ~`_connect_task` from `Device` - Check whether a device has successfully connected or if it failed to do so.~ This is dealt with in a more elegant way in c1db2d65fe261fc97fde74fbc203efe6904cea2e.

		~In regards to the second instance, I think we can come up with a more elegant way since we have access to all the connection coroutines.~ The first one, however, seems pretty fundamental, and to avoid copying code around, maybe we could ask the community about making it public.
- [x] Add relevant tests for our reasons to use ophyd-async (e.g. parallel instantiation, handling with timeouts, etc)