### PR TITLE
Fix CI tests because of kafka-python major update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
   "caproto!=1.2.0",
 ]
 kafka = [
-  "kafka-python",
+  "kafka-python<3",
   "msgpack",
   "msgpack-numpy"
 ]


### PR DESCRIPTION
Recently, kafka-python released a major release, including some breaking changes. This is currently breaking our tests. As a hotfix, we're limiting the supported versions, and in the near future we'll fix compatibility with the new release. Also, this is a pretext for adding a heart to pyproject :3