### PR TITLE
feat: add EngUnit PV for picolo device

### DIFF
--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -99,6 +99,7 @@ class PicoloChannel(Device):  # numpydoc ignore=PR01
 
     enable = Component(EpicsSignalWithRBV, "Enable", kind="config")
     engvalue = Component(EpicsSignal, "EngValue", kind="hinted")
+    engunit = Component(EpicsSignalRO, "EngUnit", kind="hinted")
     saturated = Component(EpicsSignal, "Saturated", kind="config")
     range = Component(EpicsSignalWithRBV, "Range", string=True, kind="config")
     auto_range = Component(EpicsSignalWithRBV, "AutoRange", kind="omitted")

--- a/src/sophys/common/devices/picolo.py
+++ b/src/sophys/common/devices/picolo.py
@@ -1,28 +1,29 @@
-from time import time
+from time import time  # numpydoc ignore=GL08
+
 from ophyd import (
-    Device,
     Component,
-    FormattedComponent,
-    EpicsSignal,
-    EpicsSignalWithRBV,
+    Device,
     DynamicDeviceComponent,
+    EpicsSignal,
     EpicsSignalRO,
+    EpicsSignalWithRBV,
+    FormattedComponent,
 )
 from ophyd.flyers import FlyerInterface
-from ophyd.signal import DEFAULT_WRITE_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT
-from ophyd.status import SubscriptionStatus, StatusBase, Status
+from ophyd.signal import DEFAULT_CONNECTION_TIMEOUT, DEFAULT_WRITE_TIMEOUT
+from ophyd.status import Status, StatusBase, SubscriptionStatus
 
-from ..utils.status import PremadeStatus
 from ..utils.interfaces import IEnumValidator
+from ..utils.status import PremadeStatus
 
 
-class EnumAcquisitionTimeValidator(IEnumValidator):
+class EnumAcquisitionTimeValidator(IEnumValidator):  # numpydoc ignore=PR01
     """Validates acquisition time based on predefined enum values."""
 
-    def __init__(self, enum_string):
+    def __init__(self, enum_string):  # numpydoc ignore=PR01,GL08
         self._enums = [float(item.replace(" ms", "")) / 1000 for item in enum_string]
 
-    def format_to_enum(self, value):
+    def format_to_enum(self, value):  # numpydoc ignore=GL08
         ms_value = value * 1000  # Convert seconds to milliseconds
 
         if ms_value == int(ms_value):
@@ -30,20 +31,23 @@ class EnumAcquisitionTimeValidator(IEnumValidator):
         else:
             return f"{ms_value} ms"
 
-    def validate_and_format(self, acquisition_time: float):
-        """Validate and format acquisition time."""
+    def validate_and_format(self, acquisition_time: float):  # numpydoc ignore=PR01
+        """
+        Validate and format acquisition time.
+        """
         if not self.is_valid(acquisition_time):
             raise ValueError(
                 f"The acquisition time '{acquisition_time}' ms is not a valid option."
             )
         return self.format_to_enum(acquisition_time)
 
-    def is_valid(self, enum_value: float) -> bool:
+    def is_valid(self, enum_value: float) -> bool:  # numpydoc ignore=GL08
         return enum_value in self._enums
 
 
-class PicoloAcquisitionTimeMixin:
-    """A mix-in class for handling acquisition time configuration.
+class PicoloAcquisitionTimeMixin:  # numpydoc ignore=PR01
+    """
+    A mix-in class for handling acquisition time configuration.
 
     This mix-in assumes the presence of a base interface that provides
     the methods `wait_for_connection` and `set`, which are expected to be
@@ -52,12 +56,12 @@ class PicoloAcquisitionTimeMixin:
     enumeration-based validator before passing them to the base `set` method.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # numpydoc ignore=GL08
         super().__init__(*args, **kwargs)
         self.wait_for_connection(DEFAULT_CONNECTION_TIMEOUT)
         self._time_base_validator = EnumAcquisitionTimeValidator(self.enum_strs)
 
-    def set(self, acquisition_time: float, *args, **kwargs):
+    def set(self, acquisition_time: float, *args, **kwargs):  # numpydoc ignore=GL08
         try:
             formatted_time = self._time_base_validator.validate_and_format(
                 acquisition_time
@@ -82,7 +86,7 @@ class PicoloAcquisitionTimeWithRBV(PicoloAcquisitionTimeMixin, EpicsSignalWithRB
     pass
 
 
-class PicoloChannel(Device):
+class PicoloChannel(Device):  # numpydoc ignore=PR01
     """
     Device for one of the channels in the Picolo picoammeter.
     """
@@ -113,7 +117,7 @@ class PicoloChannel(Device):
     exp_offset = Component(EpicsSignalWithRBV, "ExpOffset", kind="config")
     set_zero = Component(EpicsSignal, "SetZero", kind="omitted")
 
-    def __init__(self, prefix, **kwargs):
+    def __init__(self, prefix, **kwargs):  # numpydoc ignore=GL08
         self.continuous_value = prefix[:-1]
         super().__init__(prefix=prefix, **kwargs)
 
@@ -121,8 +125,10 @@ class PicoloChannel(Device):
 class Picolo(Device):
     """Device for the 4 channel Picolo picoammeter."""
 
-    class DataResetSignal(EpicsSignal):
-        def set(self, value, *, timeout=DEFAULT_WRITE_TIMEOUT, settle_time=None):
+    class DataResetSignal(EpicsSignal):  # numpydoc ignore=GL08
+        def set(
+            self, value, *, timeout=DEFAULT_WRITE_TIMEOUT, settle_time=None
+        ):  # numpydoc ignore=GL08
             _s = Status()
             _s.set_finished()
             if value == 0:
@@ -164,20 +170,19 @@ class Picolo(Device):
     ch4 = Component(PicoloChannel, "Current4:")
 
 
-class PicoloFlyScan(Picolo, FlyerInterface):
+class PicoloFlyScan(Picolo, FlyerInterface):  # numpydoc ignore=GL08
 
     # 1 week timeout
     complete_timeout = 604800
 
-    def kickoff(self):
+    def kickoff(self):  # numpydoc ignore=GL08
         sts = StatusBase()
         sts.set_finished()
         return sts
 
-    def _fly_scan_complete(self, **kwargs):
+    def _fly_scan_complete(self, **kwargs):  # numpydoc ignore=PR01
         """
-        Wait for the Picolo device to acquire and save the predetermined quantity
-        of values.
+        Wait for the Picolo device to acquire and save the predetermined quantity of values.
         """
         num_exposures = self.samples_per_trigger.get()
         data_acquired = self.data_acquired.get()
@@ -190,19 +195,19 @@ class PicoloFlyScan(Picolo, FlyerInterface):
                 return False
         return True
 
-    def complete(self):
+    def complete(self):  # numpydoc ignore=GL08
         return SubscriptionStatus(
             self, callback=self._fly_scan_complete, timeout=self.complete_timeout
         )
 
-    def describe_collect(self):
+    def describe_collect(self):  # numpydoc ignore=GL08
         descriptor = {"picolo": {}}
         for channel in [self.ch1, self.ch2, self.ch3, self.ch4]:
             if channel.enable.get():
                 descriptor["picolo"].update(channel.data.describe())
         return descriptor
 
-    def collect(self):
+    def collect(self):  # numpydoc ignore=GL08
         data = {}
         timestamps = {}
         for channel in [self.ch1, self.ch2, self.ch3, self.ch4]:


### PR DESCRIPTION
When working with CAT orchestration scripts,
I realized that this PV of EngUnit for Picolo was missing.
It is a read-only EpicsSignal that contains the current EGU
measured by the specific picolo channel.