### PR TITLE
feat: create StorageRingStatus Device

### DIFF
--- a/src/sophys/common/devices/storage_ring.py
+++ b/src/sophys/common/devices/storage_ring.py
@@ -1,8 +1,9 @@
+from ophyd import Component, Device  # numpydoc ignore=GL08
+
 from sophys.common.utils import EpicsSignalWithRetryRO
-from ophyd import Device, Component
 
 
-class StorageRing(Device):
+class StorageRing(Device):  # numpydoc ignore=PR01
     """Useful signals from the Storage Ring."""
 
     ring_current = Component(
@@ -12,8 +13,13 @@ class StorageRing(Device):
         timeout=5,
         connection_timeout=5,
     )
+    sofb = Component(EpicsSignalWithRetryRO, "SI-Glob:AP-SOFB:LoopState-Sts", lazy=True)
+    fofb = Component(EpicsSignalWithRetryRO, "SI-Glob:AP-FOFB:LoopState-Sts", lazy=True)
+    bbb_h = Component(EpicsSignalWithRetryRO, "SI-Glob:DI-BbBProc-H:FBCTRL", lazy=True)
+    bbb_v = Component(EpicsSignalWithRetryRO, "SI-Glob:DI-BbBProc-V:FBCTRL", lazy=True)
+    bbb_l = Component(EpicsSignalWithRetryRO, "SI-Glob:DI-BbBProc-L:FBCTRL", lazy=True)
 
     _default_read_attrs = ["ring_current"]  # noqa: RUF012
 
-    def __init__(self, *, name, **kwargs):
+    def __init__(self, *, name, **kwargs):  # numpydoc ignore=GL08
         super().__init__(prefix="", name=name, **kwargs)

--- a/src/sophys/common/devices/storage_ring.py
+++ b/src/sophys/common/devices/storage_ring.py
@@ -13,7 +13,7 @@ class StorageRing(Device):
         connection_timeout=5,
     )
 
-    _default_read_attrs = ["ring_current"]
+    _default_read_attrs = ["ring_current"]  # noqa: RUF012
 
     def __init__(self, *, name, **kwargs):
         super().__init__(prefix="", name=name, **kwargs)


### PR DESCRIPTION
The purpose of creating this device arises from a demand for the CAT orchestration scripts. There is a check of the Ring statuses along the plan, which is used as a condition to abort the plan. As it is a generic device, and not specific to CAT, the ideal would be to put it here on sophys-common.

See for more details: [sophys-cat](https://gitlab.cnpem.br/sirius/orch-apps/sophys-cat/-/merge_requests/1/diffs?commit_id=3cf21f2df1678219d91802c75276da7a034dc31f)